### PR TITLE
Fix tidyselect imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Imports:
     rlang (>= 0.4.0),
     methods,
     tidyselect (>= 1.0.0),
-    ellipsis,
     vctrs (>= 0.2.4)
 RoxygenNote: 7.1.0
 URL: https://github.com/markfairbanks/tidytable

--- a/R/bind.R
+++ b/R/bind.R
@@ -43,6 +43,7 @@ bind_rows. <- function(..., .id = NULL, use.names = TRUE, fill = TRUE) {
 dt_bind_rows <- bind_rows.
 
 #' @export
+#' @rdname bind_rows.
 bind_cols. <- function(...) {
 
   dots <- list(...)

--- a/R/select_helpers.R
+++ b/R/select_helpers.R
@@ -37,7 +37,9 @@
 #'
 #' example_dt %>%
 #'   select.(ends_with.("y"))
-starts_with. <- tidyselect::starts_with
+starts_with. <- function(match, ignore.case = TRUE, vars = NULL) {
+  tidyselect::starts_with(match, ignore.case = ignore.case, vars = vars)
+}
 
 #' @export
 #' @rdname starts_with.
@@ -45,7 +47,9 @@ dt_starts_with <- starts_with.
 
 #' @export
 #' @rdname starts_with.
-contains. <- tidyselect::contains
+contains. <- function(match, ignore.case = TRUE, vars = NULL) {
+  tidyselect::contains(match, ignore.case = ignore.case, vars = vars)
+}
 
 #' @export
 #' @rdname starts_with.
@@ -53,7 +57,9 @@ dt_contains <- contains.
 
 #' @export
 #' @rdname starts_with.
-ends_with. <- tidyselect::ends_with
+ends_with. <- function(match, ignore.case = TRUE, vars = NULL) {
+  tidyselect::ends_with(match, ignore.case = ignore.case, vars = vars)
+}
 
 #' @export
 #' @rdname starts_with.
@@ -61,7 +67,9 @@ dt_ends_with <- ends_with.
 
 #' @export
 #' @rdname starts_with.
-everything. <- tidyselect::everything
+everything. <- function(vars = NULL) {
+  tidyselect::everything(vars)
+}
 
 #' @export
 #' @rdname starts_with.
@@ -69,7 +77,9 @@ dt_everything <- everything.
 
 #' @export
 #' @rdname starts_with.
-any_of. <- tidyselect::any_of
+any_of. <- function(x, ..., vars = NULL) {
+  tidyselect::any_of(x, ..., vars = vars)
+}
 
 #' @export
 #' @rdname starts_with.

--- a/man/bind_rows..Rd
+++ b/man/bind_rows..Rd
@@ -3,12 +3,15 @@
 \name{bind_rows.}
 \alias{bind_rows.}
 \alias{dt_bind_rows}
+\alias{bind_cols.}
 \alias{dt_bind_cols}
 \title{Bind data.tables by row and column}
 \usage{
 bind_rows.(..., .id = NULL, use.names = TRUE, fill = TRUE)
 
 dt_bind_rows(..., .id = NULL, use.names = TRUE, fill = TRUE)
+
+bind_cols.(...)
 
 dt_bind_cols(...)
 }

--- a/man/starts_with..Rd
+++ b/man/starts_with..Rd
@@ -13,25 +13,25 @@
 \alias{dt_any_of}
 \title{Select helpers}
 \usage{
-starts_with.(match, ignore.case = TRUE, vars = peek_vars(fn = "starts_with"))
+starts_with.(match, ignore.case = TRUE, vars = NULL)
 
-dt_starts_with(match, ignore.case = TRUE, vars = peek_vars(fn = "starts_with"))
+dt_starts_with(match, ignore.case = TRUE, vars = NULL)
 
-contains.(match, ignore.case = TRUE, vars = peek_vars(fn = "contains"))
+contains.(match, ignore.case = TRUE, vars = NULL)
 
-dt_contains(match, ignore.case = TRUE, vars = peek_vars(fn = "contains"))
+dt_contains(match, ignore.case = TRUE, vars = NULL)
 
-ends_with.(match, ignore.case = TRUE, vars = peek_vars(fn = "ends_with"))
+ends_with.(match, ignore.case = TRUE, vars = NULL)
 
-dt_ends_with(match, ignore.case = TRUE, vars = peek_vars(fn = "ends_with"))
+dt_ends_with(match, ignore.case = TRUE, vars = NULL)
 
-everything.(vars = peek_vars(fn = "everything"))
+everything.(vars = NULL)
 
-dt_everything(vars = peek_vars(fn = "everything"))
+dt_everything(vars = NULL)
 
-any_of.(x, ..., vars = peek_vars(fn = "any_of"))
+any_of.(x, ..., vars = NULL)
 
-dt_any_of(x, ..., vars = peek_vars(fn = "any_of"))
+dt_any_of(x, ..., vars = NULL)
 }
 \arguments{
 \item{match}{A character vector. If length > 1, the union of the


### PR DESCRIPTION
Hello,

I see a CMD check failure after changing the signature of the selection helpers: https://github.com/r-lib/tidyselect/blob/master/revdep/problems.md#tidytable

This is because you've assigned the foreign helpers in your namespace. Copying foreign functions in this way should be avoided at all cost because it means the code of the copied functions doesn't get updated until the package is built again. If I make internal changes in tidyselect, they won't be reflected in the installed versions of your package, and then the outdated implementations might refer to symbols that no longer exist, among all sorts of other problems. In this case it causes a failure because of documentation mismatch.

The first commit creates an indirection around the tidyselect helpers to avoid this problem. The other two commits fix unrelated NOTE and WARNING.