### PR TITLE
Adding args to count. to mimic tidyverse's count

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
   + Added `names_prefix` arg
   + Can now use `".value"` in `names_to`
 * `pivot_wider.()`: Can now use `".value"` in `names_glue`
-
+* `count.()`: Added `wt`, `sort` and `name` args. (#196)
 # tidytable 0.5.8
 
 #### Breaking changes

--- a/R/count.R
+++ b/R/count.R
@@ -60,11 +60,9 @@ count..data.frame <- function(.df, ..., wt = NULL, sort = FALSE, name = NULL) {
   }
   
   if (sort) {
-    .df <- arrange.(.df, !!name)
+    .df <- arrange.(.df, -!!sym(name))
   }
   
-
+  
   .df
 }
-
-globalVariables("N")

--- a/R/count.R
+++ b/R/count.R
@@ -28,12 +28,26 @@ count. <- function(.df, ...) {
 }
 
 #' @export
-count..data.frame <- function(.df, ...) {
+count..data.frame <- function(.df, ..., wt = NULL, sort = FALSE, name = NULL) {
 
-  .df <- as_tidytable(.df)
+  .df <- tidytable:::as_tidytable(.df)
 
   .by <- enquos(...)
+  wt <- enquo(wt)
+  
+  if(quo_is_null(wt)){
+    .df <- summarize.(.df, N = .N, .by = c(!!!.by))
+  } else {
+    .df <- summarize.(.df, N = sum(!!wt), .by = c(!!!.by))
+  }
+  
+  if(sort) {
+    .df <- .df[order(-N)]
+  }
+  
+  if(!is.null(name)){
+    data.table::setnames(.df, "N", name)
+  }
 
-  summarize.(.df, N = .N, .by = c(!!!.by))
-
+  .df
 }

--- a/R/count.R
+++ b/R/count.R
@@ -31,6 +31,12 @@
 #'
 #' test_df %>%
 #'   count.(where(is.character))
+#' 
+#' test_df %>%
+#'   count.(z, wt = y, name = "Sum of Y")
+#' 
+#' test_df %>%
+#'   count.(z, sort = TRUE)
 count. <- function(.df, ..., wt = NULL, sort = FALSE, name = NULL) {
   UseMethod("count.")
 }

--- a/R/count.R
+++ b/R/count.R
@@ -5,7 +5,15 @@
 #'
 #' @param .df A data.frame or data.table
 #' @param ... Columns to group by. `tidyselect` compatible.
+#' @param wt Frequency weights.  `tidyselect` compatible.
+#'   Can be `NULL` or a variable:
 #'
+#'   * If `NULL` (the default), counts the number of rows in each group.
+#'   * If a variable, computes `sum(wt)` for each group.
+#' @param sort If `TRUE`, will show the largest groups at the top.
+#' @param name The name of the new column in the output.
+#'
+#'   If omitted, it will default to `N`.
 #' @export
 #' @md
 #'
@@ -23,7 +31,7 @@
 #'
 #' test_df %>%
 #'   count.(where(is.character))
-count. <- function(.df, ...) {
+count. <- function(.df, ..., wt = NULL, sort = FALSE, name = NULL) {
   UseMethod("count.")
 }
 

--- a/R/count.R
+++ b/R/count.R
@@ -44,7 +44,7 @@ count. <- function(.df, ..., wt = NULL, sort = FALSE, name = NULL) {
 #' @export
 count..data.frame <- function(.df, ..., wt = NULL, sort = FALSE, name = NULL) {
 
-  .df <- tidytable:::as_tidytable(.df)
+  .df <- as_tidytable(.df)
 
   .by <- enquos(...)
   wt <- enquo(wt)
@@ -60,8 +60,10 @@ count..data.frame <- function(.df, ..., wt = NULL, sort = FALSE, name = NULL) {
   }
   
   if(!is.null(name)){
-    data.table::setnames(.df, "N", name)
+    setnames(.df, "N", name)
   }
 
   .df
 }
+
+globalVariables("N")

--- a/R/count.R
+++ b/R/count.R
@@ -49,19 +49,20 @@ count..data.frame <- function(.df, ..., wt = NULL, sort = FALSE, name = NULL) {
   .by <- enquos(...)
   wt <- enquo(wt)
   
-  if(quo_is_null(wt)){
-    .df <- summarize.(.df, N = .N, .by = c(!!!.by))
+  if (is.null(name)) {
+    name <- "N"
+  }
+
+  if (quo_is_null(wt)) {
+    .df <- summarize.(.df, !!name := .N, .by = c(!!!.by))
   } else {
-    .df <- summarize.(.df, N = sum(!!wt), .by = c(!!!.by))
+    .df <- summarize.(.df, !!name := sum(!!wt), .by = c(!!!.by))
   }
   
-  if(sort) {
-    .df <- .df[order(-N)]
+  if (sort) {
+    .df <- arrange.(.df, !!name)
   }
   
-  if(!is.null(name)){
-    setnames(.df, "N", name)
-  }
 
   .df
 }

--- a/man/count..Rd
+++ b/man/count..Rd
@@ -4,12 +4,25 @@
 \alias{count.}
 \title{Count observations by group}
 \usage{
-count.(.df, ...)
+count.(.df, ..., wt = NULL, sort = FALSE, name = NULL)
 }
 \arguments{
 \item{.df}{A data.frame or data.table}
 
 \item{...}{Columns to group by. \code{tidyselect} compatible.}
+
+\item{wt}{Frequency weights.  \code{tidyselect} compatible.
+Can be \code{NULL} or a variable:
+\itemize{
+\item If \code{NULL} (the default), counts the number of rows in each group.
+\item If a variable, computes \code{sum(wt)} for each group.
+}}
+
+\item{sort}{If \code{TRUE}, will show the largest groups at the top.}
+
+\item{name}{The name of the new column in the output.
+
+If omitted, it will default to \code{N}.}
 }
 \description{
 Returns row counts of the dataset. If bare column names are provided, \code{count.()} returns counts by group.
@@ -28,4 +41,10 @@ test_df \%>\%
 
 test_df \%>\%
   count.(where(is.character))
+
+test_df \%>\%
+  count.(z, wt = y, name = "Sum of Y")
+
+test_df \%>\%
+  count.(z, sort = TRUE)
 }

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -30,7 +30,7 @@ below to see their documentation.
 
   \item{rlang}{\code{\link[rlang:nse-defuse]{enquo}}, \code{\link[rlang:nse-defuse]{enquos}}}
 
-  \item{tibble}{\code{\link[tibble:reexports]{glimpse}}}
+  \item{tibble}{\code{\link[tibble]{glimpse}}}
 
   \item{tidyselect}{\code{\link[tidyselect]{all_of}}, \code{\link[tidyselect:all_of]{any_of}}, \code{\link[tidyselect:starts_with]{contains}}, \code{\link[tidyselect:starts_with]{ends_with}}, \code{\link[tidyselect]{everything}}, \code{\link[tidyselect:everything]{last_col}}, \code{\link[tidyselect:starts_with]{matches}}, \code{\link[tidyselect:starts_with]{num_range}}, \code{\link[tidyselect]{starts_with}}}
 }}


### PR DESCRIPTION
This is the code used in the `PR`, note that I didn't implement the `.drop` argument but I can get to it in a later time. the way I think it should be implemented is a check on the variables if they are factors if so use `setdiff(levels(var), unique(var))` to find missing levels and `CJ` all these vectors together and append them as rows with N equals 0.
``` r
count..data.frame <- function(.df, ..., wt = NULL, sort = FALSE, name = NULL) {

  .df <- as_tidytable(.df)

  .by <- enquos(...)
  wt <- enquo(wt)
  
  if(quo_is_null(wt)){
    .df <- summarize.(.df, N = .N, .by = c(!!!.by))
  } else {
    .df <- summarize.(.df, N = sum(!!wt), .by = c(!!!.by))
  }
  
  if(sort) {
    .df <- .df[order(-N)]
  }
  
  if(!is.null(name)){
    setnames(.df, "N", name)
  }

  .df
}
```
-----
 PR Checklist:
- [x] Use "Closes #xx" somewhere in one of the commit messages if it closes an issue. For example "Added this and that. Closes #xx"
- [x] Add or update documentation (if necessary)
- [x] Run `devtools::document()` - updates documentation files
- [x] Update NEWS.md
- [ ] Add simple unit tests (if necessary)
- [ ] Run `devtools::test()` - runs unit tests
- [x] Run `devtools::check()` - makes sure everything follows CRAN rules