### PR TITLE
Copy when `let()` is used in  `dt()`

### DIFF
--- a/R/dt.R
+++ b/R/dt.R
@@ -25,11 +25,22 @@ dt <- function(.df, ...) {
 
 #' @export
 dt.tidytable <- function(.df, ...) {
-  dots <- substitute(list(...))
+  # TODO: Add test that let() doesn't modify-by-reference
+    ## once 1.14.4 is released
+  dots <- as.list(substitute(...()))
+  dots_names <- names(dots)
 
-  needs_copy <- str_detect.(expr_text(dots), ":=")
+  if (length(dots) > 1 | "j" %chin% dots_names) {
+    if ("j" %chin% dots_names) {
+      j <- dots[["j"]]
+    } else {
+      j <- dots[[2]]
+    }
 
-  if (needs_copy) .df <- copy(.df)
+    if (is_call(j, c(":=", "let"))) {
+      .df <- copy(.df)
+    }
+  }
 
   .df[...]
 }

--- a/tests/testthat/test-dt.R
+++ b/tests/testthat/test-dt.R
@@ -7,6 +7,9 @@ test_that("dt() doesn't modify by reference", {
   df %>%
     dt(, x := 2)
 
+  df %>%
+    dt(, double_x := 2)
+
   expect_named(df, c("x", "y"))
   expect_equal(df$x, c(1,1,1,1))
 })


### PR DESCRIPTION
`let()` is currently in the dev version of data.table as an alias to `':='()`. This makes sure the input data.table is copied when `let()` is used in `dt()`