### PR TITLE
Use unique dots_names for assignment in `mutate` with `.by`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 * `mutate.()`: Can use `stringr::str_glue()` without specifying `.envir`
 * `replace_na.()`: Checks that `replace` arg only uses columns that exist in the data frame
 
+#### Bug fixes
+* `mutate.()`: Can assign to the same column when `.by = character(0)` (#332)
+
 # tidytable 0.6.6
 
 #### Functionality improvements

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -117,7 +117,8 @@ mutate..tidytable <- function(.df, ..., .by = NULL,
     if (length(dots) > 0) {
       dots <- exprs_auto_name(dots)
       dots_names <- names(dots)
-      assign <- map2.(syms(dots_names), dots, ~ call2("<-", .x, .y))
+      assign <- map2.(syms(dots_names), dots, ~ call2("=", .x, .y))
+      dots_names <- unique(dots_names)
       output <- call2("list", !!!syms(dots_names))
       expr <- call2("{", !!!assign, output)
       j <- call2(":=", call2("c", !!!dots_names), expr)

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -346,4 +346,11 @@ test_that("Can use str_glue, #378", {
   expect_equal(as.character(out$new), c("a_a", "b_b", "c_c"))
 })
 
+test_that("Can assign to the same column multiple times when .by = character(0), #332", {
+  test_df <- tidytable(x = 1, y = 2)
+  out <- mutate.(test_df, x = x + 10, x = x, .by = character(0))
+  expect_named(out, c("x", "y"))
+  expect_equal(out$x, 11)
+})
+
 


### PR DESCRIPTION
Closes #332 