### PR TITLE
Only remove vars in `.by` if `NULL` is last call

### DIFF
--- a/R/mutate.R
+++ b/R/mutate.R
@@ -107,13 +107,16 @@ mutate..tidytable <- function(.df, ..., .by = NULL,
     if (needs_copy) .df <- copy(.df)
 
     # Check for NULL inputs so columns can be deleted
+    # Only delete if the NULL is the last call
     null_bool <- map_lgl.(dots, is_null)
-    any_null <- any(null_bool)
+    is_last <- !duplicated(names(dots), fromLast = TRUE)
+    needs_removal <- null_bool & is_last
+    any_null <- any(needs_removal)
 
     if (any_null) {
-      null_dots <- dots[null_bool]
+      null_dots <- dots[needs_removal]
 
-      dots <- dots[!null_bool]
+      dots <- dots[!needs_removal]
     }
 
     if (length(dots) > 0) {

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -2,8 +2,14 @@ test_that("can remove variables with NULL", {
   df <- data.table(x = rep(1, 3), y = rep(2, 3))
   tidytable_df <- mutate.(df, y = NULL)
 
-  # check that .by with NULL works
-  tidytable2_df <- mutate.(df, x_plus_y = x + y, y = NULL, .by = x)
+  # Check that .by with NULL works
+  # Only deletes if the the NULL is in the last position
+  tidytable2_df <- df %>%
+    mutate.(x = NULL,
+            x = rep(1, 3),
+            x_plus_y = x + y,
+            y = NULL,
+            .by = x)
 
   df_check <- tidytable(x = rep(1, 3), x_plus_y = rep(3, 3))
 


### PR DESCRIPTION
This now works correctly:
```r
df <- tidytable(x = 1:3, y = c("a", "a", "b"))

df %>%
  mutate.(x = NULL, x = row_number(), .by = y)

#> # A tidytable: 3 × 2
#>       x y    
#>   <dbl> <chr>
#> 1     1 a    
#> 2     2 a    
#> 3     1 b
```