### PR TITLE
Allow namespacing functions in `.fns` in `across.()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
   
 #### Bug Fixes
 * Nested calls to `across.()` are handled properly (#505)
+* Can namespace functions in `.fns` arg (#511)
 
 # tidytable 0.8.0
 

--- a/R/utils-across.R
+++ b/R/utils-across.R
@@ -49,7 +49,7 @@ expand_across <- function(.fns, .cols, .names, dots) {
 
 # Generate expression from function call
 fn_to_expr <- function(.fn, .col, ...) {
-  if (is_symbol(.fn) || is_string(.fn) || is_call(.fn, "function")) {
+  if (is_symbol(.fn) || is_string(.fn) || is_call(.fn, c("function", "::"))) {
     call2(.fn, sym(.col), ...)
   } else if (is_call(.fn, "~")) {
     call <- f_rhs(.fn)

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -202,6 +202,16 @@ test_that(".cols detects environment variables in custom functions, #389", {
   expect_equal(out$y, c("1", "2", "3"))
 })
 
+test_that("can namespace functions, #511", {
+  df <- tidytable(x = 1:3, y = 1:3)
+
+  res <- df %>%
+    summarize.(across.(.fns = base::mean))
+
+  expect_equal(res$x, 2)
+  expect_equal(res$y, 2)
+})
+
 # summarize -----------------------------------------------------
 test_that("single function works", {
   test_df <- tidytable(a = c(1:2, NA), b = 4:6, z = c("a", "a", "b"))


### PR DESCRIPTION
Closes #511 