### PR TITLE
Add `.keep_rownames`/`.name_repair` to `as_tidytable.default()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,8 @@
   
 #### Bug Fixes
 * Nested calls to `across.()` are handled properly (#505)
-* Can namespace functions in `.fns` arg (#511)
+* `across.()`: Can namespace functions in `.fns` arg (#511)
+* `as_tidytable()`: Can keep row names when converting a matrix (#527)
 
 # tidytable 0.8.0
 

--- a/R/as_tidytable.R
+++ b/R/as_tidytable.R
@@ -9,7 +9,7 @@
 #' @param x An R object
 #' @param .name_repair Treatment of duplicate names. See `?vctrs::vec_as_names` for options/details.
 #' @param .keep_rownames Default is `FALSE`. If `TRUE`, adds the input object's names as a separate
-#' column named `"rn"`. `.keep_rownames = "id"` names the column "id" instead.
+#'   column named `"rn"`. `.keep_rownames = "id"` names the column "id" instead.
 #' @param ... Additional arguments to be passed to or from other methods.
 #'
 #' @export
@@ -68,8 +68,12 @@ as_tidytable.list <- function(x, ...,
 }
 
 #' @export
-as_tidytable.default <- function(x, ...) {
-  add_tidytable_class(as.data.table(x))
+as_tidytable.default <- function(x, ...,
+                                 .name_repair = "unique",
+                                 .keep_rownames = FALSE) {
+  out <- as.data.table(x, .keep_rownames)
+  out <- add_tidytable_class(out)
+  df_name_repair(out, .name_repair = .name_repair)
 }
 
 add_tidytable_class <- function(x) {

--- a/tests/testthat/test-as_tidytable.R
+++ b/tests/testthat/test-as_tidytable.R
@@ -1,12 +1,24 @@
 test_that("works", {
+  # list
   .list <- suppressMessages(as_tidytable(list(x = 1:3, 1)))
   expect_named(.list, c("x", "...2"))
   expect_equal(.list$...2, c(1, 1, 1))
   expect_true(is_tidytable(.list))
+
+  # data.frame
   .df <- as_tidytable(data.frame(x = 1:3, y = 1:3))
   expect_named(.df, c("x", "y"))
   expect_true(is_tidytable(.df))
+
+  # data.table
   .dt <- as_tidytable(data.table(x = 1:3, y = 1:3))
   expect_named(.dt, c("x", "y"))
   expect_true(is_tidytable(.dt))
+
+  # matrix & .keep_rownames
+  m <- matrix(data = 1:3)
+  rownames(m) <- c("a","b","c")
+  .m <- as_tidytable(m, .keep_rownames = "id")
+  expect_named(.m, c("id", "V1"))
+  expect_true(is_tidytable(.m))
 })


### PR DESCRIPTION
Closes #527 