### PR TITLE
Handle empty data frame case to be consistent with tidyr::unnest

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * Nested calls to `across.()` are handled properly (#505)
 * `across.()`: Can namespace functions in `.fns` arg (#511)
 * `as_tidytable()`: Can keep row names when converting a matrix (#527)
+* `unnest.()`: Handles empty tibbles/tidytables (#530)
 
 # tidytable 0.8.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
 * Nested calls to `across.()` are handled properly (#505)
 * `across.()`: Can namespace functions in `.fns` arg (#511)
 * `as_tidytable()`: Can keep row names when converting a matrix (#527)
-* `unnest.()`: Handles empty tibbles/tidytables (#530)
+* `unnest.()`: Handles empty data frames (@roboton, #530)
 
 # tidytable 0.8.0
 

--- a/R/unnest.R
+++ b/R/unnest.R
@@ -52,6 +52,10 @@ unnest..tidytable <- function(.df,
                               names_sep = NULL,
                               names_repair = "unique") {
   vec_assert(.drop, logical(), 1)
+  
+  if (vec_is_empty(.df)) {
+    return(.df)
+  }
 
   dots <- enquos(...)
 

--- a/R/unnest.R
+++ b/R/unnest.R
@@ -52,10 +52,6 @@ unnest..tidytable <- function(.df,
                               names_sep = NULL,
                               names_repair = "unique") {
   vec_assert(.drop, logical(), 1)
-  
-  if (vec_is_empty(.df)) {
-    return(.df)
-  }
 
   dots <- enquos(...)
 
@@ -122,6 +118,10 @@ unnest_col <- function(.df, col = NULL, names_sep = NULL) {
   .l <- pull.(.df, !!col)
 
   .l <- list_drop_empty(.l)
+
+  if (length(.l) == 0) {
+    .l <- list(logical())
+  }
 
   .check_data <- .l[[1]]
   is_vec <- is_simple_vector(.check_data)

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -150,7 +150,7 @@ test_that("keep_empty", {
   expect_equal(out$vecs, c(NA, 1, 2))
 })
 
-test_that("handles empty tibble", {
-  expect_equal(unnest.(tibble::tibble(x = list()), x),
-	       tidytable(x = as.logical(list())))
+test_that("handles empty data frames", {
+  empty_df <- tidytable(x = as.logical(list()))
+  expect_equal(unnest.(tidytable(x = list()), x), empty_df)
 })

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -150,4 +150,7 @@ test_that("keep_empty", {
   expect_equal(out$vecs, c(NA, 1, 2))
 })
 
-
+test_that("handles empty tibble", {
+  expect_equal(unnest.(tibble::tibble(x = list()), x),
+	       tidytable(x = as.logical(list())))
+})


### PR DESCRIPTION
Currently tidytable::unnest. throws an error when dealing with an empty tibble:

```
> tidytable::unnest.(tibble::tibble(foo = list()), foo)
Error in .l[[1]] : subscript out of bounds
> tidyr::unnest(tibble::tibble(foo = list()), foo)
# A tibble: 0 × 1
# … with 1 variable: foo <???>
```

Closes #530 which raises this issue.