### PR TITLE
Mark old `*_across.()` as defunct

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,11 @@
 * `nth.()`: Extracts list elements (#534)
 * `arrange.()`: Properly sorts `NA`s (#541)
 
+#### Deprecations
+* `arrange_across.`/`mutate_across.`/`summarize_across.` are now defunct. They have been
+  deprecated with warnings since v0.6.4 (Jul 2021). Users must now use `across.()` inside
+  `arrange.()`/`mutate.()`/`summarize.()`.
+
 # tidytable 0.8.0
 
 #### New functions

--- a/R/arrange_across.R
+++ b/R/arrange_across.R
@@ -1,5 +1,7 @@
 #' Arrange by a selection of variables
 #'
+#' *Deprecated*
+#'
 #' Arrange all rows in either ascending or descending order by a selection of variables.
 #'
 #' @param .df A data.table or data.frame
@@ -9,6 +11,7 @@
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' df <- tidytable(a = c("a", "b", "a"), b = 3:1)
 #'
 #' df %>%
@@ -16,6 +19,7 @@
 #'
 #' df %>%
 #'   arrange_across.(a, desc.)
+#' }
 arrange_across. <- function(.df, .cols = everything(), .fns = NULL) {
   UseMethod("arrange_across.")
 }

--- a/R/mutate_across.R
+++ b/R/mutate_across.R
@@ -1,6 +1,9 @@
 #' Mutate multiple columns simultaneously
 #'
 #' @description
+#'
+#' *Deprecated*
+#'
 #' Mutate multiple columns simultaneously.
 #'
 #' @param .df A data.frame or data.table
@@ -16,6 +19,7 @@
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' df <- data.table(
 #'   x = rep(1, 3),
 #'   y = rep(2, 3),
@@ -40,6 +44,7 @@
 #'     .fns = list(new = ~ .x * 2, another = ~ .x + 7),
 #'     .names = "{.col}_test_{.fn}"
 #'   )
+#' }
 mutate_across. <- function(.df, .cols = everything(), .fns = NULL, ...,
                            .by = NULL, .names = NULL) {
   UseMethod("mutate_across.")

--- a/R/summarize_across.R
+++ b/R/summarize_across.R
@@ -1,6 +1,9 @@
 #' Summarize multiple columns
 #'
 #' @description
+#'
+#' *Deprecated*
+#'
 #' Summarize multiple columns simultaneously
 #'
 #' @param .df A data.frame or data.table
@@ -16,6 +19,7 @@
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' df <- data.table(
 #'   a = 1:3,
 #'   b = 4:6,
@@ -48,6 +52,7 @@
 #'                          max = ~ max(.x)),
 #'                     .by = z,
 #'                     .names = "{.col}_test_{.fn}")
+#' }
 summarize_across. <- function(.df, .cols = everything(), .fns = NULL, ...,
                               .by = NULL, .names = NULL) {
   UseMethod("summarize_across.")

--- a/R/utils-general.R
+++ b/R/utils-general.R
@@ -129,10 +129,11 @@ tidytable_restore <- function(x, to) {
 }
 
 deprecate_old_across <- function(fn) {
-  msg <- glue("`{fn}_across.()` was deprecated in tidytable 0.6.4.
+  msg <- glue("`{fn}_across.()` is defunct as of v0.8.1 (Aug 2022).
+              It has been deprecated with warnings since v0.6.4 (Jul 2021).
               Please use `{fn}.(across.())`")
 
-  warn_deprecated(msg = msg, id = fn)
+  stop_defunct(msg)
 }
 
 # Does type changes with either ptype or transform logic

--- a/man/arrange_across..Rd
+++ b/man/arrange_across..Rd
@@ -14,9 +14,13 @@ arrange_across.(.df, .cols = everything(), .fns = NULL)
 \item{.fns}{Function to apply. If \code{desc} it arranges in descending order}
 }
 \description{
+\emph{Deprecated}
+}
+\details{
 Arrange all rows in either ascending or descending order by a selection of variables.
 }
 \examples{
+\dontrun{
 df <- tidytable(a = c("a", "b", "a"), b = 3:1)
 
 df \%>\%
@@ -24,4 +28,5 @@ df \%>\%
 
 df \%>\%
   arrange_across.(a, desc.)
+}
 }

--- a/man/mutate_across..Rd
+++ b/man/mutate_across..Rd
@@ -30,9 +30,12 @@ The default (\code{NULL}) is equivalent to \code{"{.col}"} for a single function
 when a list is used for \code{.fns}.}
 }
 \description{
+\emph{Deprecated}
+
 Mutate multiple columns simultaneously.
 }
 \examples{
+\dontrun{
 df <- data.table(
   x = rep(1, 3),
   y = rep(2, 3),
@@ -57,4 +60,5 @@ df \%>\%
     .fns = list(new = ~ .x * 2, another = ~ .x + 7),
     .names = "{.col}_test_{.fn}"
   )
+}
 }

--- a/man/summarize_across..Rd
+++ b/man/summarize_across..Rd
@@ -40,9 +40,12 @@ The default (\code{NULL}) is equivalent to \code{"{.col}"} for a single function
 when a list is used for \code{.fns}.}
 }
 \description{
+\emph{Deprecated}
+
 Summarize multiple columns simultaneously
 }
 \examples{
+\dontrun{
 df <- data.table(
   a = 1:3,
   b = 4:6,
@@ -75,4 +78,5 @@ df \%>\%
                          max = ~ max(.x)),
                     .by = z,
                     .names = "{.col}_test_{.fn}")
+}
 }

--- a/tests/testthat/test-deprec-across.R
+++ b/tests/testthat/test-deprec-across.R
@@ -1,385 +1,392 @@
-test_that("across deprecations", {
-  test_df <- tidytable(a = c("a", "a", "b"), b = 1:3)
-
-  expect_warning(arrange_across.(test_df))
-  expect_warning(mutate_across.(test_df, everything(), identity))
-  expect_warning(summarize_across.(test_df, b, mean))
+test_that("_across are defunct", {
+  df <- tidytable(x = 1:3)
+  expect_error(arrange_across.(df))
+  expect_error(mutate_across.(df, everything(), identity))
+  expect_error(summarize_across.(df, everything(), mean))
 })
 
-test_df <- tidytable(a = c("a", "b", "a"), b = 3:1)
-
-test_that("ascending order works", {
-  across_df <- suppressWarnings(
-    arrange_across.(test_df)
-  )
-
-  check_df <- arrange.(test_df, a, b)
-
-  expect_equal(across_df, check_df)
-
-})
-
-test_that("descending order works", {
-  across_df <- arrange_across.(test_df, everything(), desc.)
-
-  check_df <- arrange.(test_df, -a, -b)
-
-  expect_equal(across_df, check_df)
-})
-
-test_that("descending order works with rlang lambda", {
-  across_df <- arrange_across.(test_df, everything(), ~ desc.(.x))
-
-  check_df <- arrange.(test_df, -a, -b)
-
-  expect_equal(across_df, check_df)
-})
-
-test_that(".cols works with is.numeric", {
-  df <- data.table(x_start = c(1,1,1), end_x = c(2,2,2), z = c("a", "a", "b"))
-  df <- df %>%
-    mutate_across.(where(is.numeric), function(.x) .x + 1) %>%
-    suppressWarnings()
-
-  expect_equal(df$x_start, c(2,2,2))
-  expect_equal(df$end_x, c(3,3,3))
-})
-
-test_that("modify-by-reference doesn't occur", {
-  df <- data.table(x_start = c(1,1,1), end_x = c(2,2,2), z = c("a", "a", "b"))
-  df %>%
-    mutate_across.(where(is.numeric), ~ .x + 1)
-
-  df %>%
-    mutate_across.(where(is.numeric), ~ 1, .by = z)
-
-  expect_equal(df$x_start, c(1,1,1))
-  expect_equal(df$end_x, c(2,2,2))
-})
-
-test_that(".cols works with is.numeric with data.frame", {
-  df <- data.frame(x_start = c(1,1,1), end_x = c(2,2,2), z = c("a", "a", "b"))
-  df <- df %>%
-    mutate_across.(where(is.numeric), function(.x) .x + 1)
-
-  expect_equal(df$x_start, c(2,2,2))
-  expect_equal(df$end_x, c(3,3,3))
-})
-
-test_that(".cols works with is.character", {
-  df <- data.table(x_start = c(1,1,1), end_x = c(2,2,2), z = c("a", "a", "b"))
-  df <- df %>%
-    mutate_across.(where(is.character), function(.x) paste0(.x, "_append"))
-
-  expect_equal(df$x_start, c(1,1,1))
-  expect_equal(df$z, c("a_append", "a_append", "b_append"))
-})
-
-test_that("works with newly named columns", {
-  df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
-  df <- df %>%
-    mutate_across.(c(x:y), list(new = function(.x) .x + 1))
-
-  expect_named(df, c("x","y","z","x_new","y_new"))
-  expect_equal(df$x_new, c(2,2,2))
-  expect_equal(df$y_new, c(3,3,3))
-})
-
-test_that("works with newly named columns using .names with single .fn", {
-  df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
-  df <- df %>%
-    mutate_across.(c(x:y), ~ .x + 1, .names = "new_{.col}")
-
-  expect_named(df, c("x","y","z","new_x","new_y"))
-  expect_equal(df$new_x, c(2,2,2))
-  expect_equal(df$new_y, c(3,3,3))
-})
-
-test_that("works with newly named columns using .names with single .fn using col", {
-  # This test will need to be removed when {col} is deprecated
-  df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
-  df <- df %>%
-    mutate_across.(c(x:y), ~ .x + 1, .names = "new_{col}")
-
-  expect_named(df, c("x","y","z","new_x","new_y"))
-  expect_equal(df$new_x, c(2,2,2))
-  expect_equal(df$new_y, c(3,3,3))
-})
-
-test_that("works with newly named columns using .names", {
-  df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
-  df <- df %>%
-    mutate_across.(c(x:y), list(new = function(.x) .x + 1), .names = "{.fn}_{.col}")
-
-  expect_named(df, c("x","y","z","new_x","new_y"))
-  expect_equal(df$new_x, c(2,2,2))
-  expect_equal(df$new_y, c(3,3,3))
-})
-
-test_that("works with newly named columns using .names with using fn and col", {
-  # This test will need to be removed when {col} and {fn} is deprecated
-  df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
-  df <- df %>%
-    mutate_across.(c(x:y), list(new = function(.x) .x + 1), .names = "{fn}_{col}")
-
-  expect_named(df, c("x","y","z","new_x","new_y"))
-  expect_equal(df$new_x, c(2,2,2))
-  expect_equal(df$new_y, c(3,3,3))
-})
-
-test_that("works with newly named columns using .names w/ autonaming", {
-  df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
-  df <- df %>%
-    mutate_across.(c(x:y), list(new = ~ .x + 1, ~ .x + 2), .names = "{.col}_{.fn}_stuff")
-
-  expect_named(df, c("x","y","z","x_new_stuff", "x_2_stuff","y_new_stuff", "y_2_stuff"))
-  expect_equal(df$x_new_stuff, c(2,2,2))
-  expect_equal(df$y_new_stuff, c(3,3,3))
-  expect_equal(df$x_2_stuff, c(3,3,3))
-  expect_equal(df$y_2_stuff, c(4,4,4))
-})
-
-# twiddle testing ----------------------------
-test_that("works with twiddle", {
-  df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
-  anon_df <- df %>%
-    mutate_across.(c(x:y), function(.x) .x + 1)
-
-  twiddle_df <- df %>%
-    mutate_across.(c(x:y), ~ .x + 1)
-
-  expect_equal(anon_df, twiddle_df)
-})
-
-test_that("works with .by, doesn't modify-by-reference", {
-  test_df <- data.table(
-    x = c(1,2,3),
-    y = c(4,5,6),
-    z = c("a","a","b"))
-
-  results_df <- test_df %>%
-    mutate_across.(c(x, y), ~ mean(.x), .by = z)
-
-  expect_named(results_df, c("x", "y", "z"))
-  expect_equal(results_df$x, c(1.5, 1.5, 3))
-  expect_equal(results_df$y, c(4.5, 4.5, 6))
-  expect_equal(test_df$x, c(1,2,3))
-})
-
-test_that(".cols doesn't use .by columns", {
-  test_df <- data.table(
-    x = c(1,2,3),
-    y = c(4,5,6),
-    z = c("a","a","b")
-  )
-
-  results_df <- test_df %>%
-    mutate_across.(everything(), ~ mean(.x), .by = z)
-
-  expect_named(results_df, c("x", "y", "z"))
-  expect_equal(results_df$x, c(1.5, 1.5, 3))
-  expect_equal(results_df$y, c(4.5, 4.5, 6))
-  expect_equal(test_df$x, c(1,2,3))
-})
-
-test_that("works with .by enhanced selection", {
-  test_df <- data.table(
-    x = c(1,2,3),
-    y = c(4,5,6),
-    z = c("a","a","b"))
-
-  results_df <- test_df %>%
-    mutate_across.(c(x, y), ~ mean(.x), .by = where(is.character))
-
-  expect_named(results_df, c("x", "y", "z"))
-  expect_equal(results_df$x, c(1.5, 1.5, 3))
-  expect_equal(results_df$y, c(4.5, 4.5, 6))
-})
-
-test_that("_across.() can refer to variables in the data.table", {
-  test_df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
-
-  results_df <- test_df %>%
-    mutate_across.(c(x, y), ~ .x + y)
-
-  expect_equal(results_df$x, c(3,3,3))
-  expect_equal(results_df$y, c(4,4,4))
-})
-
-test_that("_across.() can refer to variables in the data.table w/ list of .fns", {
-  test_df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
-
-  results_df <- test_df %>%
-    mutate_across.(x, list(~ .x + 1, new = ~ .x + y))
-
-  expect_equal(results_df$x_1, c(2,2,2))
-  expect_equal(results_df$x_new, c(3,3,3))
-})
-
-test_that("_across.() can use bare functions", {
-  test_df <- tidytable(x = 1:3, y = 2:4, z = c("a", "a", "b"))
-
-  results_df <- test_df %>%
-    mutate_across.(c(x, y), between, 1, 3)
-
-  expect_equal(results_df$x, c(TRUE, TRUE, TRUE))
-  expect_equal(results_df$y, c(TRUE, TRUE, FALSE))
-})
-
-test_that("can be used in custom functions", {
-  df <- data.table(x_start = c(1,1,1), end_x = c(2,2,2), z = c("a", "a", "b"))
-
-  mutate_across_fn <- function(data, cols, val) {
-    data %>%
-      mutate_across.({{ cols }}, ~ .x + val)
-  }
-
-  df <- df %>%
-    mutate_across_fn(where(is.numeric), 1)
-
-  expect_equal(df$x_start, c(2,2,2))
-  expect_equal(df$end_x, c(3,3,3))
-})
-
-test_that("single function works", {
-  test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
-
-  result_df <- test_df %>%
-    summarize_across.(c(a, b), mean, na.rm = TRUE) %>%
-    suppressWarnings()
-
-  expect_named(result_df, c("a", "b"))
-  expect_equal(result_df$a, 2)
-  expect_equal(result_df$b, 5)
-})
-
-test_that("can use anonymous functions", {
-  test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
-
-  result_df <- test_df %>%
-    summarize_across.(c(a, b), ~ mean(.x, na.rm = TRUE))
-
-  expect_named(result_df, c("a", "b"))
-  expect_equal(result_df$a, 2)
-  expect_equal(result_df$b, 5)
-})
-
-test_that("can use other columns", {
-  test_df <- tidytable(a = 1:3, b = 1:3, z = c("a", "a", "b"))
-
-  result_df <- test_df %>%
-    summarize_across.(c(a, b), ~ mean(.x)/mean(b))
-
-  expect_named(result_df, c("a", "b"))
-  expect_equal(result_df$a, 1)
-  expect_equal(result_df$b, 1)
-})
-
-test_that("summarise spelling works", {
-  test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
-
-  result_df <- test_df %>%
-    summarise_across.(c(a, b), mean, na.rm = TRUE)
-
-  expect_named(result_df, c("a", "b"))
-  expect_equal(result_df$a, 2)
-  expect_equal(result_df$b, 5)
-})
-
-test_that("single function works with .by", {
-  test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
-
-  result_df <- test_df %>%
-    summarize_across.(c(a, b), mean, na.rm = TRUE, .by = z)
-
-  expect_named(result_df, c("z", "a", "b"))
-  expect_equal(result_df$a, c(1.5, 3))
-  expect_equal(result_df$b, c(4.5, 6))
-})
-
-test_that(".cols doesn't use .by columns", {
-  test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
-
-  result_df <- test_df %>%
-    summarize_across.(everything(), mean, na.rm = TRUE, .by = z)
-
-  expect_named(result_df, c("z", "a", "b"))
-  expect_equal(result_df$a, c(1.5, 3))
-  expect_equal(result_df$b, c(4.5, 6))
-})
-
-test_that("can pass list of named functions", {
-  test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
-
-  result_df <- test_df %>%
-    summarize_across.(c(a, b), list(avg = mean, max = max))
-
-  expect_named(result_df, c("a_avg", "a_max", "b_avg", "b_max"))
-  expect_equal(result_df$a_avg, 2)
-  expect_equal(result_df$b_avg, 5)
-  expect_equal(result_df$a_max, 3)
-  expect_equal(result_df$b_max, 6)
-
-  result_df <- test_df %>%
-    summarize_across.(c(a, b), list(avg = ~ mean(.x), max = ~ max(.x)))
-
-  expect_named(result_df, c("a_avg", "a_max", "b_avg", "b_max"))
-  expect_equal(result_df$a_avg, 2)
-  expect_equal(result_df$b_avg, 5)
-  expect_equal(result_df$a_max, 3)
-  expect_equal(result_df$b_max, 6)
-})
-
-test_that("can pass list of functions with no names", {
-  test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
-
-  result_df <- test_df %>%
-    summarize_across.(c(a, b), list(mean, max))
-
-  expect_named(result_df, c("a_1", "a_2", "b_1", "b_2"))
-  expect_equal(result_df$a_1, 2)
-  expect_equal(result_df$b_1, 5)
-  expect_equal(result_df$a_2, 3)
-  expect_equal(result_df$b_2, 6)
-})
-
-test_that("can pass list of functions with some names", {
-  test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
-
-  result_df <- test_df %>%
-    summarize_across.(c(a, b), list(avg = mean, max))
-
-  expect_named(result_df, c("a_avg", "a_2", "b_avg", "b_2"))
-  expect_equal(result_df$a_avg, 2)
-  expect_equal(result_df$b_avg, 5)
-  expect_equal(result_df$a_2, 3)
-  expect_equal(result_df$b_2, 6)
-})
-
-test_that("can pass list of named functions with .by and .names", {
-  test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
-
-  result_df <- test_df %>%
-    summarize_across.(c(a, b), list(avg = mean, max = max), .by = z, .names = "{.fn}_{.col}")
-
-  expect_named(result_df, c("z", "avg_a", "max_a", "avg_b", "max_b"))
-  expect_equal(result_df$avg_a, c(1.5, 3))
-  expect_equal(result_df$avg_b, c(4.5, 6))
-  expect_equal(result_df$max_a, c(2, 3))
-  expect_equal(result_df$max_b, c(5, 6))
-})
-
-test_that("can pass list of named functions with .by and .names using fn and col", {
-  # This test will need to be removed when {col} and {fn} is deprecated
-
-  test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
-
-  result_df <- test_df %>%
-    summarize_across.(c(a, b), list(avg = mean, max = max), .by = z, .names = "{fn}_{col}")
-
-  expect_named(result_df, c("z", "avg_a", "max_a", "avg_b", "max_b"))
-  expect_equal(result_df$avg_a, c(1.5, 3))
-  expect_equal(result_df$avg_b, c(4.5, 6))
-  expect_equal(result_df$max_a, c(2, 3))
-  expect_equal(result_df$max_b, c(5, 6))
-})
+# test_that("across deprecations", {
+#   test_df <- tidytable(a = c("a", "a", "b"), b = 1:3)
+#
+#   expect_warning(arrange_across.(test_df))
+#   expect_warning(mutate_across.(test_df, everything(), identity))
+#   expect_warning(summarize_across.(test_df, b, mean))
+# })
+#
+# test_df <- tidytable(a = c("a", "b", "a"), b = 3:1)
+#
+# test_that("ascending order works", {
+#   across_df <- suppressWarnings(
+#     arrange_across.(test_df)
+#   )
+#
+#   check_df <- arrange.(test_df, a, b)
+#
+#   expect_equal(across_df, check_df)
+#
+# })
+#
+# test_that("descending order works", {
+#   across_df <- arrange_across.(test_df, everything(), desc.)
+#
+#   check_df <- arrange.(test_df, -a, -b)
+#
+#   expect_equal(across_df, check_df)
+# })
+#
+# test_that("descending order works with rlang lambda", {
+#   across_df <- arrange_across.(test_df, everything(), ~ desc.(.x))
+#
+#   check_df <- arrange.(test_df, -a, -b)
+#
+#   expect_equal(across_df, check_df)
+# })
+#
+# test_that(".cols works with is.numeric", {
+#   df <- data.table(x_start = c(1,1,1), end_x = c(2,2,2), z = c("a", "a", "b"))
+#   df <- df %>%
+#     mutate_across.(where(is.numeric), function(.x) .x + 1) %>%
+#     suppressWarnings()
+#
+#   expect_equal(df$x_start, c(2,2,2))
+#   expect_equal(df$end_x, c(3,3,3))
+# })
+#
+# test_that("modify-by-reference doesn't occur", {
+#   df <- data.table(x_start = c(1,1,1), end_x = c(2,2,2), z = c("a", "a", "b"))
+#   df %>%
+#     mutate_across.(where(is.numeric), ~ .x + 1)
+#
+#   df %>%
+#     mutate_across.(where(is.numeric), ~ 1, .by = z)
+#
+#   expect_equal(df$x_start, c(1,1,1))
+#   expect_equal(df$end_x, c(2,2,2))
+# })
+#
+# test_that(".cols works with is.numeric with data.frame", {
+#   df <- data.frame(x_start = c(1,1,1), end_x = c(2,2,2), z = c("a", "a", "b"))
+#   df <- df %>%
+#     mutate_across.(where(is.numeric), function(.x) .x + 1)
+#
+#   expect_equal(df$x_start, c(2,2,2))
+#   expect_equal(df$end_x, c(3,3,3))
+# })
+#
+# test_that(".cols works with is.character", {
+#   df <- data.table(x_start = c(1,1,1), end_x = c(2,2,2), z = c("a", "a", "b"))
+#   df <- df %>%
+#     mutate_across.(where(is.character), function(.x) paste0(.x, "_append"))
+#
+#   expect_equal(df$x_start, c(1,1,1))
+#   expect_equal(df$z, c("a_append", "a_append", "b_append"))
+# })
+#
+# test_that("works with newly named columns", {
+#   df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
+#   df <- df %>%
+#     mutate_across.(c(x:y), list(new = function(.x) .x + 1))
+#
+#   expect_named(df, c("x","y","z","x_new","y_new"))
+#   expect_equal(df$x_new, c(2,2,2))
+#   expect_equal(df$y_new, c(3,3,3))
+# })
+#
+# test_that("works with newly named columns using .names with single .fn", {
+#   df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
+#   df <- df %>%
+#     mutate_across.(c(x:y), ~ .x + 1, .names = "new_{.col}")
+#
+#   expect_named(df, c("x","y","z","new_x","new_y"))
+#   expect_equal(df$new_x, c(2,2,2))
+#   expect_equal(df$new_y, c(3,3,3))
+# })
+#
+# test_that("works with newly named columns using .names with single .fn using col", {
+#   # This test will need to be removed when {col} is deprecated
+#   df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
+#   df <- df %>%
+#     mutate_across.(c(x:y), ~ .x + 1, .names = "new_{col}")
+#
+#   expect_named(df, c("x","y","z","new_x","new_y"))
+#   expect_equal(df$new_x, c(2,2,2))
+#   expect_equal(df$new_y, c(3,3,3))
+# })
+#
+# test_that("works with newly named columns using .names", {
+#   df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
+#   df <- df %>%
+#     mutate_across.(c(x:y), list(new = function(.x) .x + 1), .names = "{.fn}_{.col}")
+#
+#   expect_named(df, c("x","y","z","new_x","new_y"))
+#   expect_equal(df$new_x, c(2,2,2))
+#   expect_equal(df$new_y, c(3,3,3))
+# })
+#
+# test_that("works with newly named columns using .names with using fn and col", {
+#   # This test will need to be removed when {col} and {fn} is deprecated
+#   df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
+#   df <- df %>%
+#     mutate_across.(c(x:y), list(new = function(.x) .x + 1), .names = "{fn}_{col}")
+#
+#   expect_named(df, c("x","y","z","new_x","new_y"))
+#   expect_equal(df$new_x, c(2,2,2))
+#   expect_equal(df$new_y, c(3,3,3))
+# })
+#
+# test_that("works with newly named columns using .names w/ autonaming", {
+#   df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
+#   df <- df %>%
+#     mutate_across.(c(x:y), list(new = ~ .x + 1, ~ .x + 2), .names = "{.col}_{.fn}_stuff")
+#
+#   expect_named(df, c("x","y","z","x_new_stuff", "x_2_stuff","y_new_stuff", "y_2_stuff"))
+#   expect_equal(df$x_new_stuff, c(2,2,2))
+#   expect_equal(df$y_new_stuff, c(3,3,3))
+#   expect_equal(df$x_2_stuff, c(3,3,3))
+#   expect_equal(df$y_2_stuff, c(4,4,4))
+# })
+#
+# # twiddle testing ----------------------------
+# test_that("works with twiddle", {
+#   df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
+#   anon_df <- df %>%
+#     mutate_across.(c(x:y), function(.x) .x + 1)
+#
+#   twiddle_df <- df %>%
+#     mutate_across.(c(x:y), ~ .x + 1)
+#
+#   expect_equal(anon_df, twiddle_df)
+# })
+#
+# test_that("works with .by, doesn't modify-by-reference", {
+#   test_df <- data.table(
+#     x = c(1,2,3),
+#     y = c(4,5,6),
+#     z = c("a","a","b"))
+#
+#   results_df <- test_df %>%
+#     mutate_across.(c(x, y), ~ mean(.x), .by = z)
+#
+#   expect_named(results_df, c("x", "y", "z"))
+#   expect_equal(results_df$x, c(1.5, 1.5, 3))
+#   expect_equal(results_df$y, c(4.5, 4.5, 6))
+#   expect_equal(test_df$x, c(1,2,3))
+# })
+#
+# test_that(".cols doesn't use .by columns", {
+#   test_df <- data.table(
+#     x = c(1,2,3),
+#     y = c(4,5,6),
+#     z = c("a","a","b")
+#   )
+#
+#   results_df <- test_df %>%
+#     mutate_across.(everything(), ~ mean(.x), .by = z)
+#
+#   expect_named(results_df, c("x", "y", "z"))
+#   expect_equal(results_df$x, c(1.5, 1.5, 3))
+#   expect_equal(results_df$y, c(4.5, 4.5, 6))
+#   expect_equal(test_df$x, c(1,2,3))
+# })
+#
+# test_that("works with .by enhanced selection", {
+#   test_df <- data.table(
+#     x = c(1,2,3),
+#     y = c(4,5,6),
+#     z = c("a","a","b"))
+#
+#   results_df <- test_df %>%
+#     mutate_across.(c(x, y), ~ mean(.x), .by = where(is.character))
+#
+#   expect_named(results_df, c("x", "y", "z"))
+#   expect_equal(results_df$x, c(1.5, 1.5, 3))
+#   expect_equal(results_df$y, c(4.5, 4.5, 6))
+# })
+#
+# test_that("_across.() can refer to variables in the data.table", {
+#   test_df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
+#
+#   results_df <- test_df %>%
+#     mutate_across.(c(x, y), ~ .x + y)
+#
+#   expect_equal(results_df$x, c(3,3,3))
+#   expect_equal(results_df$y, c(4,4,4))
+# })
+#
+# test_that("_across.() can refer to variables in the data.table w/ list of .fns", {
+#   test_df <- data.table(x = c(1,1,1), y = c(2,2,2), z = c("a", "a", "b"))
+#
+#   results_df <- test_df %>%
+#     mutate_across.(x, list(~ .x + 1, new = ~ .x + y))
+#
+#   expect_equal(results_df$x_1, c(2,2,2))
+#   expect_equal(results_df$x_new, c(3,3,3))
+# })
+#
+# test_that("_across.() can use bare functions", {
+#   test_df <- tidytable(x = 1:3, y = 2:4, z = c("a", "a", "b"))
+#
+#   results_df <- test_df %>%
+#     mutate_across.(c(x, y), between, 1, 3)
+#
+#   expect_equal(results_df$x, c(TRUE, TRUE, TRUE))
+#   expect_equal(results_df$y, c(TRUE, TRUE, FALSE))
+# })
+#
+# test_that("can be used in custom functions", {
+#   df <- data.table(x_start = c(1,1,1), end_x = c(2,2,2), z = c("a", "a", "b"))
+#
+#   mutate_across_fn <- function(data, cols, val) {
+#     data %>%
+#       mutate_across.({{ cols }}, ~ .x + val)
+#   }
+#
+#   df <- df %>%
+#     mutate_across_fn(where(is.numeric), 1)
+#
+#   expect_equal(df$x_start, c(2,2,2))
+#   expect_equal(df$end_x, c(3,3,3))
+# })
+#
+# test_that("single function works", {
+#   test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
+#
+#   result_df <- test_df %>%
+#     summarize_across.(c(a, b), mean, na.rm = TRUE) %>%
+#     suppressWarnings()
+#
+#   expect_named(result_df, c("a", "b"))
+#   expect_equal(result_df$a, 2)
+#   expect_equal(result_df$b, 5)
+# })
+#
+# test_that("can use anonymous functions", {
+#   test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
+#
+#   result_df <- test_df %>%
+#     summarize_across.(c(a, b), ~ mean(.x, na.rm = TRUE))
+#
+#   expect_named(result_df, c("a", "b"))
+#   expect_equal(result_df$a, 2)
+#   expect_equal(result_df$b, 5)
+# })
+#
+# test_that("can use other columns", {
+#   test_df <- tidytable(a = 1:3, b = 1:3, z = c("a", "a", "b"))
+#
+#   result_df <- test_df %>%
+#     summarize_across.(c(a, b), ~ mean(.x)/mean(b))
+#
+#   expect_named(result_df, c("a", "b"))
+#   expect_equal(result_df$a, 1)
+#   expect_equal(result_df$b, 1)
+# })
+#
+# test_that("summarise spelling works", {
+#   test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
+#
+#   result_df <- test_df %>%
+#     summarise_across.(c(a, b), mean, na.rm = TRUE)
+#
+#   expect_named(result_df, c("a", "b"))
+#   expect_equal(result_df$a, 2)
+#   expect_equal(result_df$b, 5)
+# })
+#
+# test_that("single function works with .by", {
+#   test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
+#
+#   result_df <- test_df %>%
+#     summarize_across.(c(a, b), mean, na.rm = TRUE, .by = z)
+#
+#   expect_named(result_df, c("z", "a", "b"))
+#   expect_equal(result_df$a, c(1.5, 3))
+#   expect_equal(result_df$b, c(4.5, 6))
+# })
+#
+# test_that(".cols doesn't use .by columns", {
+#   test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
+#
+#   result_df <- test_df %>%
+#     summarize_across.(everything(), mean, na.rm = TRUE, .by = z)
+#
+#   expect_named(result_df, c("z", "a", "b"))
+#   expect_equal(result_df$a, c(1.5, 3))
+#   expect_equal(result_df$b, c(4.5, 6))
+# })
+#
+# test_that("can pass list of named functions", {
+#   test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
+#
+#   result_df <- test_df %>%
+#     summarize_across.(c(a, b), list(avg = mean, max = max))
+#
+#   expect_named(result_df, c("a_avg", "a_max", "b_avg", "b_max"))
+#   expect_equal(result_df$a_avg, 2)
+#   expect_equal(result_df$b_avg, 5)
+#   expect_equal(result_df$a_max, 3)
+#   expect_equal(result_df$b_max, 6)
+#
+#   result_df <- test_df %>%
+#     summarize_across.(c(a, b), list(avg = ~ mean(.x), max = ~ max(.x)))
+#
+#   expect_named(result_df, c("a_avg", "a_max", "b_avg", "b_max"))
+#   expect_equal(result_df$a_avg, 2)
+#   expect_equal(result_df$b_avg, 5)
+#   expect_equal(result_df$a_max, 3)
+#   expect_equal(result_df$b_max, 6)
+# })
+#
+# test_that("can pass list of functions with no names", {
+#   test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
+#
+#   result_df <- test_df %>%
+#     summarize_across.(c(a, b), list(mean, max))
+#
+#   expect_named(result_df, c("a_1", "a_2", "b_1", "b_2"))
+#   expect_equal(result_df$a_1, 2)
+#   expect_equal(result_df$b_1, 5)
+#   expect_equal(result_df$a_2, 3)
+#   expect_equal(result_df$b_2, 6)
+# })
+#
+# test_that("can pass list of functions with some names", {
+#   test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
+#
+#   result_df <- test_df %>%
+#     summarize_across.(c(a, b), list(avg = mean, max))
+#
+#   expect_named(result_df, c("a_avg", "a_2", "b_avg", "b_2"))
+#   expect_equal(result_df$a_avg, 2)
+#   expect_equal(result_df$b_avg, 5)
+#   expect_equal(result_df$a_2, 3)
+#   expect_equal(result_df$b_2, 6)
+# })
+#
+# test_that("can pass list of named functions with .by and .names", {
+#   test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
+#
+#   result_df <- test_df %>%
+#     summarize_across.(c(a, b), list(avg = mean, max = max), .by = z, .names = "{.fn}_{.col}")
+#
+#   expect_named(result_df, c("z", "avg_a", "max_a", "avg_b", "max_b"))
+#   expect_equal(result_df$avg_a, c(1.5, 3))
+#   expect_equal(result_df$avg_b, c(4.5, 6))
+#   expect_equal(result_df$max_a, c(2, 3))
+#   expect_equal(result_df$max_b, c(5, 6))
+# })
+#
+# test_that("can pass list of named functions with .by and .names using fn and col", {
+#   # This test will need to be removed when {col} and {fn} is deprecated
+#
+#   test_df <- tidytable(a = 1:3, b = 4:6, z = c("a", "a", "b"))
+#
+#   result_df <- test_df %>%
+#     summarize_across.(c(a, b), list(avg = mean, max = max), .by = z, .names = "{fn}_{col}")
+#
+#   expect_named(result_df, c("z", "avg_a", "max_a", "avg_b", "max_b"))
+#   expect_equal(result_df$avg_a, c(1.5, 3))
+#   expect_equal(result_df$avg_b, c(4.5, 6))
+#   expect_equal(result_df$max_a, c(2, 3))
+#   expect_equal(result_df$max_b, c(5, 6))
+# })


### PR DESCRIPTION
Closes #543 
