### PR TITLE
`pivot_wider.()` invalid names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 #### Bug fixes
 * `tidytable::'%in%'` dispatches to `base::'%in%'` when comparing with a list (#563)
+* `pivot_wider.()`: Works with column names with spaces (#569)
 
 # tidytable 0.8.1
 

--- a/R/pivot_wider.R
+++ b/R/pivot_wider.R
@@ -46,7 +46,7 @@ pivot_wider. <- function(.df,
                          names_prefix = "",
                          names_glue = NULL,
                          names_sort = FALSE,
-                         names_repair = "check_unique",
+                         names_repair = "unique",
                          values_fill = NULL,
                          values_fn = NULL) {
   UseMethod("pivot_wider.")
@@ -61,7 +61,7 @@ pivot_wider..tidytable <- function(.df,
                                   names_prefix = "",
                                   names_glue = NULL,
                                   names_sort = FALSE,
-                                  names_repair = "check_unique",
+                                  names_repair = "unique",
                                   values_fill = NULL,
                                   values_fn = NULL) {
   id_cols <- enquo(id_cols)
@@ -112,10 +112,10 @@ pivot_wider..tidytable <- function(.df,
   if (no_id) {
     lhs <- "..."
   } else {
-    lhs <- paste(id_cols, collapse = " + ")
+    lhs <- paste(glue("`{id_cols}`"), collapse = " + ")
   }
 
-  rhs <- paste(names_from, collapse = " + ")
+  rhs <- paste(glue("`{names_from}`"), collapse = " + ")
 
   dcast_form <- paste(lhs, rhs, sep = " ~ ")
 
@@ -156,7 +156,7 @@ pivot_wider..data.frame <- function(.df,
                                     names_prefix = "",
                                     names_glue = NULL,
                                     names_sort = FALSE,
-                                    names_repair = "check_unique",
+                                    names_repair = "unique",
                                     values_fill = NULL,
                                     values_fn = NULL) {
   .df <- as_tidytable(.df)

--- a/tests/testthat/test-pivot_wider.R
+++ b/tests/testthat/test-pivot_wider.R
@@ -179,3 +179,12 @@ test_that("values_fill only affects missing cells", {
   out <- pivot_wider.(df, names_from = names, values_from = value, values_fill = 0)
   expect_equal(out$y, c(0, NA))
 })
+
+test_that("can pivot data frames with spaced names, #569", {
+  df <- tidytable("a a" = 1,
+                  "names" = c("a", "b"),
+                  "vals" = 1:2)
+  out <- pivot_wider.(df, names_from = col, values_from = vals)
+  expect_named(out, c("a a", "a", "b"))
+})
+

--- a/tests/testthat/test-pivot_wider.R
+++ b/tests/testthat/test-pivot_wider.R
@@ -184,7 +184,7 @@ test_that("can pivot data frames with spaced names, #569", {
   df <- tidytable("a a" = 1,
                   "names" = c("a", "b"),
                   "vals" = 1:2)
-  out <- pivot_wider.(df, names_from = col, values_from = vals)
+  out <- pivot_wider.(df, names_from = names, values_from = vals)
   expect_named(out, c("a a", "a", "b"))
 })
 


### PR DESCRIPTION
Closes #569 