### PR TITLE
Column names order in "pivot_wider" with "glue_names"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 #### Bug fixes
 * `tidytable::'%in%'` dispatches to `base::'%in%'` when comparing with a list (#563)
 * `pivot_wider.()`: Works with column names with spaces (#569)
-* `pivot_wider.()`: `names_glue="{.value}_{somecolumn}"` assigns column names in correct order (#579)
+* `pivot_wider.()`: `names_glue="{.value}_{somecolumn}"` assigns column names in correct order (@Darxor, #579)
 
 # tidytable 0.8.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 #### Bug fixes
 * `tidytable::'%in%'` dispatches to `base::'%in%'` when comparing with a list (#563)
 * `pivot_wider.()`: Works with column names with spaces (#569)
+* `pivot_wider.()`: `names_glue="{.value}_{somecolumn}"` assigns column names in correct order (#579)
 
 # tidytable 0.8.1
 

--- a/R/pivot_wider.R
+++ b/R/pivot_wider.R
@@ -70,12 +70,7 @@ pivot_wider..tidytable <- function(.df,
   names_from <- tidyselect_names(.df, {{ names_from }})
   values_from <- tidyselect_names(.df, {{ values_from }})
 
-  uses_dot_value <- FALSE
-  if (!is.null(names_glue)) {
-    if (str_detect.(names_glue, ".value")) {
-      uses_dot_value <- TRUE
-    }
-  }
+  uses_dot_value <- !is.null(names_glue) && str_detect.(names_glue, ".value")
 
   if (quo_is_null(id_cols)) {
     data_names <- names(.df)

--- a/R/pivot_wider.R
+++ b/R/pivot_wider.R
@@ -91,9 +91,16 @@ pivot_wider..tidytable <- function(.df,
     glue_df <- distinct.(.df, !!!syms(names_from))
     values_from_reps <- nrow(glue_df)
     glue_df <- vec_rep(glue_df, length(values_from))
-    glue_df$.value <- vec_rep_each(values_from, values_from_reps)
+    glue_df <- mutate.(glue_df,
+                       .value = vec_rep_each(values_from, values_from_reps),
+                       .before = 1)
 
     glue_vars <- as.character(glue_data(glue_df, names_glue))
+    # mimic column names assigned by data.table::dcast()
+    if (length(values_from) <= 1) {
+      glue_df[[".value"]] <- NULL
+    }
+    names(glue_vars) <- do.call(paste, c(glue_df, list(sep = names_sep)))
   } else if (!is.null(names_glue)) {
     .df <- mutate.(.df, .names_from = glue(.env$names_glue))
     .df <- relocate.(.df, .names_from, .before = !!sym(names_from[[1]]))
@@ -134,7 +141,7 @@ pivot_wider..tidytable <- function(.df,
   if (uses_dot_value) {
     new_vars <- setdiff(names(.df), id_cols)
 
-    .df <- df_set_names(.df, glue_vars, new_vars)
+    .df <- df_set_names(.df, glue_vars[new_vars], new_vars)
   }
 
   .df <- df_name_repair(.df, .name_repair = names_repair)

--- a/R/pivot_wider.R
+++ b/R/pivot_wider.R
@@ -98,9 +98,9 @@ pivot_wider..tidytable <- function(.df,
     glue_vars <- as.character(glue_data(glue_df, names_glue))
     # mimic column names assigned by data.table::dcast()
     if (length(values_from) <= 1) {
-      glue_df[[".value"]] <- NULL
+      glue_df <- dt_j(glue_df, .value := NULL)
     }
-    names(glue_vars) <- do.call(paste, c(glue_df, list(sep = names_sep)))
+    names(glue_vars) <- exec(paste, !!!glue_df, sep = names_sep)
   } else if (!is.null(names_glue)) {
     .df <- mutate.(.df, .names_from = glue(.env$names_glue))
     .df <- relocate.(.df, .names_from, .before = !!sym(names_from[[1]]))

--- a/tests/testthat/test-pivot_wider.R
+++ b/tests/testthat/test-pivot_wider.R
@@ -188,3 +188,38 @@ test_that("can pivot data frames with spaced names, #569", {
   expect_named(out, c("a a", "a", "b"))
 })
 
+# names_glue column order ----------------------------------------------------------
+test_that("correctly labels columns when `names_glue` is used, #579", {
+  # length(values_from) == 1
+  df1 <- tidytable(
+    lettr = c("b", "a", "c"),
+    v1 = c("b", "a", "c")
+  )
+
+  result1 <- pivot_wider.(
+    df1,
+    names_from = lettr,
+    values_from = v1,
+    names_glue = "{.value}_{lettr}"
+  )
+
+  expect_named(result1, c("v1_a", "v1_b", "v1_c"))
+  expect_equal(unname(unlist(result1)), c("a", "b", "c"))
+
+  # length(values_from) > 1
+  df2 <- tidytable(
+    lettr = c("b", "a", "c"),
+    v1 = c("b", "a", "c"),
+    v2 = c("b", "a", "c")
+  )
+
+  result2 <- pivot_wider.(
+    df2,
+    names_from = lettr,
+    values_from = c(v1, v2),
+    names_glue = "{.value}_{lettr}"
+  )
+
+  expect_named(result2, c("v1_a", "v1_b", "v1_c", "v2_a", "v2_b", "v2_c"))
+  expect_equal(unname(unlist(result2)), c("a", "b", "c", "a", "b", "c"))
+})


### PR DESCRIPTION
Fixes #579 

Variable `glue_vars` now has names, that mimic `data.table::dcast`'s output column names
These names are used to map values onto new column names after `dcast` call

Tests should also probably be added to cover this edge case. 