### PR TITLE
Revert auto-splice of data frame input in `summarize()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,21 +5,19 @@
   The `verb.()` versions are still exported as well.
   * The `verb.()` syntax will remain in the package.
   * This will also allow users to use both `tidytable` and `dplyr` by simply loading
-    `dplyr` _after_ `tidytable`, as the `verb.()` functions won't be overwritten by `dplyr.
+    `dplyr` _after_ `tidytable`, as the `verb.()` functions won't be overwritten by `dplyr`.
 
 #### New functions
 * `dplyr`-style interface to grouping
   * `group_by()`/`ungroup()`
   * `group_vars()`
   * `is_grouped_df()`
-  
-#### Functionality improvements
-* `summarize()` auto-splices data frame inputs (#576)
 
 #### Bug fixes
 * `tidytable::'%in%'` dispatches to `base::'%in%'` when comparing with a list (#563)
 * `pivot_wider.()`: Works with column names with spaces (#569)
-* `pivot_wider.()`: `names_glue="{.value}_{somecolumn}"` assigns column names in correct order (@Darxor, #579)
+* `pivot_wider.()`: `names_glue="{.value}_{somecolumn}"` assigns column names in
+  correct order (@Darxor, #579)
 
 # tidytable 0.8.1
 

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -60,7 +60,7 @@ summarize.tidytable <- function(.df, ..., .by = NULL, .sort = TRUE) {
 
     .by <- tidyselect_names(.df, !!.by)
 
-    j <- call2("df_list", !!!dots, .ns = "vctrs")
+    j <- call2(".", !!!dots)
 
     dt_expr <- call2_j(.df, j, .by, .sort)
 

--- a/tests/testthat/test-summarize.R
+++ b/tests/testthat/test-summarize.R
@@ -212,17 +212,3 @@ test_that("works with grouped_tt & .groups", {
 
   expect_equal(tidytable_df, check_df)
 })
-
-test_that("auto-splice data frame inputs", {
-  df <- tidytable(group = c("a", "a", "b"), val = 1:3)
-
-  fun <- function(x) {
-    data.frame(mean = mean(x), max = max(x))
-  }
-
-  res <- df %>%
-    summarize(fun(val), .by = group)
-
-  expect_named(res, c("group", "mean", "max"))
-  expect_equal(res$mean, c(1.5, 3))
-})


### PR DESCRIPTION
Unfortunately #588 led to a pretty large performance loss.

See #576 