### PR TITLE
In operator compatibility

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # tidytable 0.9.1 (in development)
 #### Functionality improvements
-* tidytable::`%in%` no longer overwrites base::`%in% (#632)
+* tidytable::`%in%` no longer overwrites base::`%in%` (#632)
 
 
 # tidytable 0.9.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # tidytable 0.9.1 (in development)
+#### Functionality improvements
+* tidytable::`%in%` no longer overwrites base::`%in% (#632)
+
 
 # tidytable 0.9.0
 

--- a/R/case_match.R
+++ b/R/case_match.R
@@ -35,7 +35,7 @@ case_match. <- case_match
 
 prep_case_match_dot <- function(dot, .x) {
   lhs <- f_lhs(dot)
-  lhs <- call2("%in%", .x, lhs, .ns = "tidytable")
+  lhs <- call2("%in.%", .x, lhs, .ns = "tidytable")
   f_lhs(dot) <- lhs
   dot
 }

--- a/R/in-notin.R
+++ b/R/in-notin.R
@@ -1,4 +1,4 @@
-#' `%in%` and `%notin%` operators
+#' `%in.%` and `%notin%` operators
 #'
 #' @description
 #' Check with values in a vector are in or not in another vector.
@@ -7,6 +7,8 @@
 #'
 #' @param x vector or NULL
 #' @param y vector or NULL
+#'
+#' @export
 #'
 #' @examples
 #' df <- tidytable(x = 1:4, y = 1:4)

--- a/R/in-notin.R
+++ b/R/in-notin.R
@@ -19,7 +19,7 @@
 #' df %>%
 #'   filter(x %notin% c(2, 4))
 #' @rdname in-notin
-'%in%' <- function(x, y) {
+'%in.%' <- function(x, y) {
   if (is.character(x) && is.character(y)) {
     x %chin% y
   } else if (is.list(y)) {
@@ -33,7 +33,7 @@
 #' @export
 #' @rdname in-notin
 '%notin%' <- function(x, y) {
-  !x %in% y
+  !x %in.% y
 }
 
 

--- a/R/in-notin.R
+++ b/R/in-notin.R
@@ -8,8 +8,6 @@
 #' @param x vector or NULL
 #' @param y vector or NULL
 #'
-#' @export
-#'
 #' @examples
 #' df <- tidytable(x = 1:4, y = 1:4)
 #'

--- a/R/utils-prep_exprs.R
+++ b/R/utils-prep_exprs.R
@@ -46,6 +46,7 @@ call_fns <- c(
   "if_all.",  "if_all",
   "if_any.", "if_any",
   "ifelse",
+  "%in%",
   "n.", "n",
   "row_number.", "row_number",
   "str_glue"
@@ -69,6 +70,10 @@ prep_expr_call <- function(x, data, .by = NULL, j = FALSE, dt_env = caller_env()
     x <- unname(x)
     x[[1]] <- quote(tidytable::if_else)
     x[-1] <- lapply(x[-1], prep_expr, data, {{ .by }}, j, dt_env, is_top_across)
+    x
+  } else if (is_call(x, "%in%", ns = "")) {
+    x <- call_match(x, base::`%in%`)
+    x[[1]] <- quote(tidytable::`%in.%)
     x
   } else if (is_call(x, c("c_across.", "c_across"))) {
     call <- call_match(x, tidytable::c_across.)

--- a/R/utils-prep_exprs.R
+++ b/R/utils-prep_exprs.R
@@ -73,7 +73,7 @@ prep_expr_call <- function(x, data, .by = NULL, j = FALSE, dt_env = caller_env()
     x
   } else if (is_call(x, "%in%", ns = "")) {
     x <- call_match(x, base::`%in%`)
-    x[[1]] <- quote(tidytable::`%in.%)
+    x[[1]] <- quote(tidytable::`%in.%`)
     x
   } else if (is_call(x, c("c_across.", "c_across"))) {
     call <- call_match(x, tidytable::c_across.)

--- a/tests/testthat/test-in-notin.R
+++ b/tests/testthat/test-in-notin.R
@@ -4,6 +4,10 @@ test_that("%in.% works", {
   expect_equal(c("a", "d") %in.% c("a", "b"), c(TRUE, FALSE))
 })
 
+test_that("%in% checks types when used inside a tidytable verb", {
+  expect_error(cars %>% mutate(test = "a" %in% mpg), "Can't combine")
+})
+
 test_that("properly handles character comparison with NA", {
   expect_equal(c("a", "b") %in.% NA, c(FALSE, FALSE))
 })

--- a/tests/testthat/test-in-notin.R
+++ b/tests/testthat/test-in-notin.R
@@ -1,15 +1,15 @@
 # %in% ----------------------------------------------------
 
-test_that("%in% works", {
-  expect_equal(c("a", "d") %in% c("a", "b"), c(TRUE, FALSE))
+test_that("%in.% works", {
+  expect_equal(c("a", "d") %in.% c("a", "b"), c(TRUE, FALSE))
 })
 
 test_that("properly handles character comparison with NA", {
-  expect_equal(c("a", "b") %in% NA, c(FALSE, FALSE))
+  expect_equal(c("a", "b") %in.% NA, c(FALSE, FALSE))
 })
 
 test_that("can compare to a list, #565", {
-  expect_equal(c(1, 2) %in% list(1), c(TRUE, FALSE))
+  expect_equal(c(1, 2) %in.% list(1), c(TRUE, FALSE))
 })
 
 # %notin% ----------------------------------------------------


### PR DESCRIPTION
Suggestion to make the fast %in% operator apply inside tidytable verbs only.
Closes #632
