### PR TITLE
In operator fallback to base

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # tidytable 0.9.1 (in development)
 
 #### Functionality improvements
-* %in% falls back to base::`%in%` when input types aren't compatible with vec_in. (#632)
+* %in% falls back to base::`%in%` when input types aren't compatible with vec_in. (@krterberg, #632)
 
 # tidytable 0.9.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidytable 0.9.1 (in development)
 
+#### Functionality improvements
+* %in% falls back to base::`%in%` when input types aren't compatible with vec_in. (#632)
+
 # tidytable 0.9.0
 
 #### Dotless functions!

--- a/R/in-notin.R
+++ b/R/in-notin.R
@@ -8,6 +8,9 @@
 #' @param x vector or NULL
 #' @param y vector or NULL
 #'
+#' @details
+#' Falls back to base::`%in%` when x and y don't share a common type. This means that the behaviour of base::`%in%` is preserved (e.g. "1" %in% c(1, 2) is TRUE) but loses the speedup provided by vec_in.
+#'
 #' @export
 #'
 #' @examples
@@ -22,12 +25,19 @@
 '%in%' <- function(x, y) {
   if (is.character(x) && is.character(y)) {
     x %chin% y
-  } else if (is.list(y)) {
-    # https://github.com/markfairbanks/tidytable/issues/565
+  } else if (needs_base_in(x, y)) {
     base::'%in%'(x, y)
   } else {
     vec_in(x, y)
   }
+}
+
+#' check if inputs are not compatible with vec_in for the fast path of %in%
+#' @noRd
+needs_base_in <- function(x, y) {
+  # https://github.com/markfairbanks/tidytable/issues/565
+  # https://github.com/markfairbanks/tidytable/issues/632
+  tryCatch({vec_ptype_common(x, y); FALSE}, error = function(e) TRUE)
 }
 
 #' @export

--- a/R/in-notin.R
+++ b/R/in-notin.R
@@ -9,7 +9,9 @@
 #' @param y vector or NULL
 #'
 #' @details
-#' Falls back to base::`%in%` when x and y don't share a common type. This means that the behaviour of base::`%in%` is preserved (e.g. "1" %in% c(1, 2) is TRUE) but loses the speedup provided by vec_in.
+#' Falls back to base::`%in%` when x and y don't share a common type.
+#' This means that the behaviour of base::`%in%` is preserved (e.g. "1" %in% c(1, 2) is TRUE)
+#' but loses the speedup provided by vec_in.
 #'
 #' @export
 #'

--- a/R/in-notin.R
+++ b/R/in-notin.R
@@ -27,11 +27,19 @@
 '%in%' <- function(x, y) {
   if (is.character(x) && is.character(y)) {
     x %chin% y
-  } else if (vec_ptype_common(x, y)) {
+  } else if (vec_ptype_compatible(x, y)) {
     vec_in(x, y)
   } else {
     base::'%in%'(x, y)
   }
+}
+
+#' Check if two vectors have compatible ptypes
+#' @noRd
+vec_ptype_compatible <- function(x, y) {
+  # https://github.com/markfairbanks/tidytable/issues/565
+  # https://github.com/markfairbanks/tidytable/issues/632
+  tryCatch({vec_ptype_common(x, y); TRUE}, error = function(e) FALSE)
 }
 
 #' @export

--- a/R/in-notin.R
+++ b/R/in-notin.R
@@ -27,10 +27,10 @@
 '%in%' <- function(x, y) {
   if (is.character(x) && is.character(y)) {
     x %chin% y
-  } else if (needs_base_in(x, y)) {
-    base::'%in%'(x, y)
-  } else {
+  } else if (vec_ptype_compatible(x, y)) {
     vec_in(x, y)
+  } else {
+    base::'%in%'(x, y)
   }
 }
 

--- a/R/in-notin.R
+++ b/R/in-notin.R
@@ -27,19 +27,11 @@
 '%in%' <- function(x, y) {
   if (is.character(x) && is.character(y)) {
     x %chin% y
-  } else if (vec_ptype_compatible(x, y)) {
+  } else if (vec_ptype_common(x, y)) {
     vec_in(x, y)
   } else {
     base::'%in%'(x, y)
   }
-}
-
-#' check if inputs are not compatible with vec_in for the fast path of %in%
-#' @noRd
-needs_base_in <- function(x, y) {
-  # https://github.com/markfairbanks/tidytable/issues/565
-  # https://github.com/markfairbanks/tidytable/issues/632
-  tryCatch({vec_ptype_common(x, y); FALSE}, error = function(e) TRUE)
 }
 
 #' @export

--- a/man/in-notin.Rd
+++ b/man/in-notin.Rd
@@ -19,6 +19,9 @@ Check with values in a vector are in or not in another vector.
 
 Built using \verb{data.table::\%chin\%} and \code{vctrs::vec_in} for performance.
 }
+\details{
+Falls back to base::\code{\%in\%} when x and y don't share a common type. This means that the behaviour of base::\code{\%in\%} is preserved (e.g. "1" \%in\% c(1, 2) is TRUE) but loses the speedup provided by vec_in.
+}
 \examples{
 df <- tidytable(x = 1:4, y = 1:4)
 

--- a/man/in-notin.Rd
+++ b/man/in-notin.Rd
@@ -20,7 +20,9 @@ Check with values in a vector are in or not in another vector.
 Built using \verb{data.table::\%chin\%} and \code{vctrs::vec_in} for performance.
 }
 \details{
-Falls back to base::\code{\%in\%} when x and y don't share a common type. This means that the behaviour of base::\code{\%in\%} is preserved (e.g. "1" \%in\% c(1, 2) is TRUE) but loses the speedup provided by vec_in.
+Falls back to base::\code{\%in\%} when x and y don't share a common type.
+This means that the behaviour of base::\code{\%in\%} is preserved (e.g. "1" \%in\% c(1, 2) is TRUE)
+but loses the speedup provided by vec_in.
 }
 \examples{
 df <- tidytable(x = 1:4, y = 1:4)

--- a/tests/testthat/test-in-notin.R
+++ b/tests/testthat/test-in-notin.R
@@ -4,6 +4,10 @@ test_that("%in% works", {
   expect_equal(c("a", "d") %in% c("a", "b"), c(TRUE, FALSE))
 })
 
+test_that("%in% falls back to base implementatrion on arguments that don't share a prototype", {
+  expect_equal(c("1", "4") %in% c(1, 2), c(TRUE, FALSE))
+})
+
 test_that("properly handles character comparison with NA", {
   expect_equal(c("a", "b") %in% NA, c(FALSE, FALSE))
 })

--- a/tests/testthat/test-in-notin.R
+++ b/tests/testthat/test-in-notin.R
@@ -4,7 +4,7 @@ test_that("%in% works", {
   expect_equal(c("a", "d") %in% c("a", "b"), c(TRUE, FALSE))
 })
 
-test_that("%in% falls back to base implementatrion on arguments that don't share a prototype", {
+test_that("%in% falls back to base implementation on arguments that don't share a prototype", {
   expect_equal(c("1", "4") %in% c(1, 2), c(TRUE, FALSE))
 })
 


### PR DESCRIPTION
Have %in% fall back to standard library behaviour when vec_in can't be used.
Add note about possibility of performance regression when incompatible types are supplied.
Closes #632