### PR TITLE
Better handling of incorrect number of columns specified in `into` arg in `separate()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # tidytable 0.9.2 (in development)
 
+#### Functionality improvements
+* `separate()`: Can now handle when too many or two few new names are
+  specified in `into` arg (#666)
+
 # tidytable 0.9.1
 
 #### New functions

--- a/tests/testthat/test-separate.R
+++ b/tests/testthat/test-separate.R
@@ -38,8 +38,8 @@ test_that("works with sep", {
     separate(x, c("c1", "c2"), " ")
 
   expect_named(df, c("c1", "c2"))
-  expect_equal(df$c1, c("a","a","a",NA))
-  expect_equal(df$c2, c(NA,"b","b",NA))
+  expect_equal(df$c1, c("a","a","a", NA))
+  expect_equal(df$c2, c(NA, "b", "b", NA))
 })
 
 test_that("can keep initial column", {
@@ -50,8 +50,8 @@ test_that("can keep initial column", {
 
   expect_named(df, c("x", "c1", "c2"))
   expect_equal(df$x, c("a", "a b", "a b", NA))
-  expect_equal(df$c1, c("a","a","a",NA))
-  expect_equal(df$c2, c(NA,"b","b",NA))
+  expect_equal(df$c1, c("a", "a", "a", NA))
+  expect_equal(df$c2, c(NA, "b", "b", NA))
 })
 
 test_that("works automatically with data.frame", {
@@ -61,8 +61,8 @@ test_that("works automatically with data.frame", {
     separate(x, c("c1", "c2"))
 
   expect_named(df, c("c1", "c2"))
-  expect_equal(df$c1, c("a","a","a",NA))
-  expect_equal(df$c2, c(NA,"b","b",NA))
+  expect_equal(df$c1, c("a", "a", "a",NA))
+  expect_equal(df$c2, c(NA, "b", "b",NA))
 })
 
 test_that("can drop columns using NA, #288", {
@@ -72,5 +72,25 @@ test_that("can drop columns using NA, #288", {
     separate(x, c("c1", NA))
 
   expect_named(df, c("c1"))
-  expect_equal(df$c1, c("a","a","a",NA))
+  expect_equal(df$c1, c("a", "a", "a", NA))
+})
+
+test_that("fills extra columns with NA", {
+  df <- tidytable(x = c("a_a", "b_b", "c_c"))
+
+  res <- df %>%
+    separate(x, c("one", "two", "three"))
+
+  expect_named(res, c("one", "two", "three"))
+  expect_equal(res$three, as.character(rep(NA_character_, 3)))
+})
+
+test_that("works when too few columns are specified", {
+  df <- tidytable(x = c("a_a", "b_b", "c_c"))
+
+  res <- df %>%
+    separate(x, "one")
+
+  expect_named(res, "one")
+  expect_equal(res$one, c("a", "b", "c"))
 })


### PR DESCRIPTION
Closes #666 
