### PR TITLE
`case_when()`: Use `.default` when calculating common ptype

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidytable 0.10.1 (in development)
 
+#### Bug fixes
+* `case_when()`: `.default` is used when calculating a common ptype (#751)
+
 # tidytable 0.10.0
 
 #### Deprecations

--- a/R/case.R
+++ b/R/case.R
@@ -28,14 +28,15 @@ case <- function(..., default = NA, ptype = NULL, size = NULL) {
     abort("The length of conditions does not equal the length of values")
   }
 
-  conditions_locs <- as.logical(seq_len(dots_length) %% 2)
+  is_condition <- as.logical(seq_len(dots_length) %% 2)
 
-  conditions <- dots[conditions_locs]
+  conditions <- dots[is_condition]
   size <- vec_size_common(!!!conditions, .size = size)
   conditions <- vec_recycle_common(!!!conditions, .size = size)
 
-  values <- dots[!conditions_locs]
-  ptype <- vec_ptype_common(!!!values, .ptype = ptype)
+  values <- dots[!is_condition]
+  ptype <- vec_ptype_common(!!!values, default, .ptype = ptype)
+
   values <- vec_cast_common(!!!values, .to = ptype)
 
   pairs <- vec_interleave(conditions, values)

--- a/tests/testthat/test-case_when.R
+++ b/tests/testthat/test-case_when.R
@@ -63,6 +63,17 @@ test_that("passes through `.size` correctly", {
   expect_identical(res, c(1, 1))
 })
 
+test_that("use `.default` to find common ptype", {
+  df <- tidytable(x = 1:3, y = c("a", "b", "c"))
+
+  res <- df %>%
+    mutate(case = case_when(y == "a" ~ NA,
+                            .default = x)) %>%
+    pull(case)
+
+  expect_equal(res, c(NA, 2, 3))
+})
+
 test_that("case_when. works", {
   x <- 1:5
 


### PR DESCRIPTION
Closes #751 
