### PR TITLE
Properly handle `NA` as `FALSE` when using `filter(.by = )`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 #### Bug fixes
 * Attempting to rename columns using `group_by()` now leads to an error (#799)
 * `pmap()` family works with data frame inputs (#803)
+* `filter()` properly handles when comparing to `NA` when `.by` is used (#812)
 
 # tidytable 0.11.0
 

--- a/R/utils-general.R
+++ b/R/utils-general.R
@@ -37,6 +37,8 @@ call2_i_by <- function(.df, i, .by) {
   j <- expr(.I[!!i])
   dt_expr <- call2_j(.df, j, .by)
   dt_expr <- call2("$", dt_expr, expr(V1))
+  # Properly handle NA equality, #812
+  dt_expr <- call2("replace_na", dt_expr, expr(FALSE), .ns = "tidytable")
   dt_expr <- call2_i(.df, dt_expr)
   dt_expr
 }

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -152,3 +152,14 @@ test_that("works on a grouped_tt", {
   expect_equal(group_vars(res), "y")
   expect_true(is_grouped_df(res))
 })
+
+test_that("properly handles NA comparisons when `.by` is used, #812", {
+  df <- data.table(x = c(1, NA), y = c("a", "b"))
+
+  res <- df %>%
+    filter(x == 1, .by = y)
+
+  expect_named(res, c("x", "y"))
+  expect_equal(res$x, 1)
+  expect_equal(res$y, "a")
+})


### PR DESCRIPTION
Closes #812 
