### PR TITLE
Allow empty `dt()` with no warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidytable 0.11.2 (in development)
 
+#### Bug fixes
+* `dt()` works with no warning, #824
+
 # tidytable 0.11.1
 
 #### Functionality improvements

--- a/R/dt.R
+++ b/R/dt.R
@@ -40,7 +40,7 @@ dt <- function(.df, i, j, ...) {
 dt.tidytable <- function(.df, i, j, ...) {
   args <- enquos(i, j, ..., .unquote_names = FALSE, .ignore_empty = "none")
 
-  if (has_length(args, 0)) return(.df)
+  if (all(map_lgl(args, quo_is_missing))) return(.df)
 
   dt_env <- get_dt_env(args)
 

--- a/tests/testthat/test-dt.R
+++ b/tests/testthat/test-dt.R
@@ -133,3 +133,9 @@ test_that("let works", {
   expect_named(res, c("x", "double_x"))
   expect_equal(res$double_x, c(2, 2, 2))
 })
+
+test_that("no warning on empty dt, #824", {
+  df <- tidytable(x = c(1, 1, 1), y = 1:3)
+
+  expect_no_warning(df %>% dt())
+})


### PR DESCRIPTION
Closes #824 
