### PR TITLE
Fix NA support in pivot_longer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidytable
 Title: Tidy Interface to 'data.table'
-Version: 0.11.2.9
+Version: 0.11.2.10
 Authors@R: c(
   person("Mark", "Fairbanks", role = c("aut", "cre"), email = "mark.t.fairbanks@gmail.com"),
   person("Abdessabour", "Moutik", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidytable 0.11.3 (in development)
 
+* use `set()` instead of `!!` to support `pivot_longer(names_to=NA)`.
+
 # tidytable 0.11.2
 
 #### Bug fixes

--- a/R/pivot_longer.R
+++ b/R/pivot_longer.R
@@ -177,7 +177,7 @@ pivot_longer.tidytable <- function(.df,
       .value_ids <- NULL
     }
 
-    out <- mutate(out, !!variable_name := .env$.value_ids)
+    set(out, j=variable_name, value=.value_ids)
   } else if (multiple_names_to && !uses_dot_value) {
     if (!is.null(names_sep)) {
       out <- separate(out, !!sym(variable_name), into = names_to, sep = names_sep)


### PR DESCRIPTION
Hi @markfairbanks 
`data.table` implemented a change in its GitHub dev version recently, https://github.com/Rdatatable/data.table/pull/6167
and our revdep checks told us that this change causes a new test failure in tidytable, 
```
* checking tests ...
  Running ‘testthat.R’
 ERROR
Running the tests in ‘tests/testthat.R’ failed.
Last 13 lines of output:
  The following object is masked from 'package:base':
  
      %in%
  
  > 
  > test_check("tidytable")
  [ FAIL 1 | WARN 0 | SKIP 0 | PASS 1335 ]
  
  ══ Failed tests ════════════════════════════════════════════════════════════════
  ── Failure ('test-pivot_longer.R:229:3'): can drop the 'id' column by specifying NA ──
  Names of `out` ('.id', 'x', 'y') don't match 'x', 'y'
  
  [ FAIL 1 | WARN 0 | SKIP 0 | PASS 1335 ]
  Error: Test failures
```
Above is only reproducible using the dev version of `data.table` from Github (not using current CRAN release).
This PR submits a fix, so that tidytable should work with the new `data.table` code.
Can you please review, merge, and then submit a new version of `tidytable` to CRAN?
We would like to submit a new version of `data.table` to CRAN in the next few weeks, and CRAN requires `data.table` to ensure compatibility with all of its reverse dependencies (such as tidytable).
Thanks!