### PR TITLE
vctrs type/size stability for map2_ and pmap_ vector variants

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 
 #### Breaking changes
 * `unnest(.drop = FALSE)` is now the default to match `tidyr` behavior, #836
+* `map2_*()` and `pmap_*()` vector variants now use `purrr`/`vctrs` type and size rules rather than base R coercion, #843
 
 # tidytable 0.11.2
 

--- a/R/purrr-map.R
+++ b/R/purrr-map.R
@@ -90,7 +90,8 @@ map_vec <- function(.x, .f, ..., .ptype = NULL) {
 
 # Simplify a list of values to a vector of their common type
 # Ensures every element has size 1
-list_simplify <- function(x, ptype = NULL) {
-  list_check_all_size(x, 1)
-  list_unchop(x, ptype = ptype)
+list_simplify <- function(x, ptype = NULL, call = caller_env()) {
+  list_check_all_vectors(x, call = call)
+  list_check_all_size(x, 1L, call = call)
+  vec_c(!!!x, .ptype = ptype, .error_call = call)
 }

--- a/R/purrr-map2.R
+++ b/R/purrr-map2.R
@@ -13,25 +13,25 @@ map2 <- function(.x, .y, .f, ...) {
 #' @export
 #' @rdname map
 map2_lgl <- function(.x, .y, .f, ...) {
-  as.logical(map2(.x, .y, .f, ...))
+  list_simplify(map2(.x, .y, .f, ...), logical())
 }
 
 #' @export
 #' @rdname map
 map2_int <- function(.x, .y, .f, ...) {
-  as.integer(map2(.x, .y, .f, ...))
+  list_simplify(map2(.x, .y, .f, ...), integer())
 }
 
 #' @export
 #' @rdname map
 map2_dbl <- function(.x, .y, .f, ...) {
-  as.double(map2(.x, .y, .f, ...))
+  list_simplify(map2(.x, .y, .f, ...), double())
 }
 
 #' @export
 #' @rdname map
 map2_chr <- function(.x, .y, .f, ...) {
-  as.character(map2(.x, .y, .f, ...))
+  list_simplify(map2(.x, .y, .f, ...), character())
 }
 
 #' @export
@@ -55,6 +55,5 @@ map2_df <- map2_dfr
 #' @export
 #' @rdname map
 map2_vec <- function(.x, .y, .f, ..., .ptype = NULL) {
-  out <- map2(.x, .y, .f, ...)
-  list_simplify(out, .ptype)
+  list_simplify(map2(.x, .y, .f, ...), .ptype)
 }

--- a/R/purrr-pmap.R
+++ b/R/purrr-pmap.R
@@ -21,25 +21,25 @@ pmap <- function(.l, .f, ...) {
 #' @export
 #' @rdname map
 pmap_lgl <- function(.l, .f, ...) {
-  as.logical(pmap(.l, .f, ...))
+  list_simplify(pmap(.l, .f, ...), logical())
 }
 
 #' @export
 #' @rdname map
 pmap_int <- function(.l, .f, ...) {
-  as.integer(pmap(.l, .f, ...))
+  list_simplify(pmap(.l, .f, ...), integer())
 }
 
 #' @export
 #' @rdname map
 pmap_dbl <- function(.l, .f, ...) {
-  as.double(pmap(.l, .f, ...))
+  list_simplify(pmap(.l, .f, ...), double())
 }
 
 #' @export
 #' @rdname map
 pmap_chr <- function(.l, .f, ...) {
-  as.character(pmap(.l, .f, ...))
+  list_simplify(pmap(.l, .f, ...), character())
 }
 
 #' @export
@@ -63,16 +63,10 @@ pmap_df <- pmap_dfr
 #' @export
 #' @rdname map
 pmap_vec <- function(.l, .f, ..., .ptype = NULL) {
-  out <- pmap(.l, .f, ...)
-  list_simplify(out, .ptype)
+  list_simplify(pmap(.l, .f, ...), .ptype)
 }
 
 .args_recycle <- function(args) {
   args <- as.list(args)
-  sizes <- list_sizes(args)
-  n <- max(sizes)
-
-  args <- map(args, vec_recycle, n)
-
-  args
+  vec_recycle_common(!!!args, .arg = ".l", .call = caller_env())
 }

--- a/tests/testthat/test-purrr.R
+++ b/tests/testthat/test-purrr.R
@@ -74,4 +74,102 @@ test_that("pmap works", {
   expect_equal(names(res), c("a", "b"))
 })
 
+test_that("map2_* vector variants have vctrs type safety", {
+  expect_error(map2_lgl(1:3, 1:3, ~ .x + .y))
+  expect_error(map2_int(1:3, 1.5:3.5, ~ .x + .y))
+  # double is richer type
+  expect_no_error(map2_dbl(1L, 1L, ~ .x + .y))
+  expect_error(map2_dbl(1, "1", ~ paste0(.x, .y)))
+  expect_error(map2_chr(Sys.time(), 45, ~ .x + .y))
 
+  expect_error(map2_vec(1:3, 1:3, ~ .x + .y, .ptype = logical()))
+  expect_error(map2_vec(1:3, 1.5:3.5, ~ .x + .y, .ptype = integer()))
+  # double is richer type
+  expect_no_error(map2_vec(1L, 1L, ~ .x + .y, .ptype = double()))
+  expect_error(map2_vec(1, "1", ~ paste0(.x, .y), .ptype = double()))
+  expect_error(map2_vec(Sys.time(), 45, ~ .x + .y, .ptype = double()))
+
+  # no .ptype casts to common richer type
+  .vec <- map2_vec(
+    c(TRUE, FALSE, FALSE), list(1L, 2L, 3.5), ~ if (.x) {
+      .x
+    } else {
+      .y
+    }
+  )
+  expect_equal(.vec, c(1.0, 2.0, 3.5))
+})
+
+test_that("pmap_* vector variants have vctrs type safety", {
+  expect_error(pmap_lgl(list(1:3, 1:3), ~ .x + .y))
+  expect_error(pmap_int(list(1:3, 1.5:3.5), ~ .x + .y))
+  # double is richer type
+  expect_no_error(pmap_dbl(list(1L, 1L), ~ .x + .y))
+  expect_error(pmap_dbl(list(1, "1"), ~ paste0(.x, .y)))
+  expect_error(pmap_chr(list(Sys.time(), 45), ~ .x + .y))
+
+  expect_error(pmap_vec(list(1:3, 1:3), ~ .x + .y, .ptype = logical()))
+  expect_error(pmap_vec(list(1:3, 1.5:3.5), ~ .x + .y, .ptype = integer()))
+  # double is richer type
+  expect_no_error(pmap_vec(list(1L, 1L), ~ .x + .y, .ptype = double()))
+  expect_error(pmap_vec(list(1, "1"), ~ paste0(.x, .y), .ptype = double()))
+  expect_error(pmap_vec(list(Sys.time(), 45), ~ .x + .y, .ptype = double()))
+
+  # no .ptype casts to common richer type
+  .vec <- pmap_vec(
+    list(c(TRUE, FALSE, FALSE), list(1L, 2L, 3.5)), ~ if (.x) {
+      .x
+    } else {
+      .y
+    }
+  )
+  expect_equal(.vec, c(1.0, 2.0, 3.5))
+})
+
+test_that("map2_* vector variants error when result not length 1", {
+  # length 0
+  expect_error(map2_lgl(1:3, 1:3, ~ logical()))
+  expect_error(map2_int(1:3, 1:3, ~ integer()))
+  expect_error(map2_dbl(1:3, 1:3, ~ double()))
+  expect_error(map2_chr(1:3, 1:3, ~ character()))
+  expect_error(map2_vec(1:3, 1:3, ~ integer()))
+
+  # length > 1
+  expect_error(map2_lgl(1:3, 1:3, ~ c(TRUE, FALSE)))
+  expect_error(map2_int(1:3, 1:3, ~ c(1L, 2L)))
+  expect_error(map2_dbl(1:3, 1:3, ~ c(1, 2)))
+  expect_error(map2_chr(1:3, 1:3, ~ c("a", "b")))
+  expect_error(map2_vec(1:3, 1:3, ~ c(1L, 2L)))
+
+  # NULL
+  expect_error(map2_lgl(1:3, 1:3, ~ NULL))
+  expect_error(map2_int(1:3, 1:3, ~ NULL))
+  expect_error(map2_dbl(1:3, 1:3, ~ NULL))
+  expect_error(map2_chr(1:3, 1:3, ~ NULL))
+  expect_error(map2_vec(1:3, 1:3, ~ NULL))
+})
+
+test_that("pmap_* vector variants error when result not length 1", {
+  .l <- list(x = 1:3, y = 1:3)
+
+  # length 0
+  expect_error(pmap_lgl(.l, ~ logical()))
+  expect_error(pmap_int(.l, ~ integer()))
+  expect_error(pmap_dbl(.l, ~ double()))
+  expect_error(pmap_chr(.l, ~ character()))
+  expect_error(pmap_vec(.l, ~ integer()))
+
+  # length > 1
+  expect_error(pmap_lgl(.l, ~ c(TRUE, FALSE)))
+  expect_error(pmap_int(.l, ~ c(1L, 2L)))
+  expect_error(pmap_dbl(.l, ~ c(1, 2)))
+  expect_error(pmap_chr(.l, ~ c("a", "b")))
+  expect_error(pmap_vec(.l, ~ c(1L, 2L)))
+
+  # NULL
+  expect_error(pmap_lgl(.l, ~ NULL))
+  expect_error(pmap_int(.l, ~ NULL))
+  expect_error(pmap_dbl(.l, ~ NULL))
+  expect_error(pmap_chr(.l, ~ NULL))
+  expect_error(pmap_vec(.l, ~ NULL))
+})


### PR DESCRIPTION
Closes #843 

Modified `list_simplify` and `.args_recycle` for type/size, but also for clearer error messages.
